### PR TITLE
add episode 113 transcript

### DIFF
--- a/src/_transcripts/113.json
+++ b/src/_transcripts/113.json
@@ -1,7 +1,7 @@
 {
   "speakers": {
-    "spk_0": "spk_0",
-    "spk_1": "spk_1"
+    "spk_0": "Luciano",
+    "spk_1": "Eoin"
   },
   "segments": [
     {
@@ -86,13 +86,13 @@
       "speakerLabel": "spk_0",
       "start": 71,
       "end": 76,
-      "text": " AWS Bites is brought to you by FortiorM, an AWS consulting partner that doesn't suck,"
+      "text": " AWS Bites is brought to you by fourTheorem, an AWS consulting partner that doesn't suck,"
     },
     {
       "speakerLabel": "spk_0",
       "start": 76,
       "end": 81.36,
-      "text": " or rarely suck at least. So if you want to check us out, go to FortiorM.com,"
+      "text": " or rarely suck at least. So if you want to check us out, go to fourTheorem.com,"
     },
     {
       "speakerLabel": "spk_0",
@@ -110,7 +110,7 @@
       "speakerLabel": "spk_0",
       "start": 90.24,
       "end": 92.92,
-      "text": " so you know that you shouldn't be using act-context credentials."
+      "text": " so you know that you shouldn't be using hardcoded credentials."
     },
     {
       "speakerLabel": "spk_0",

--- a/src/_transcripts/113.vtt
+++ b/src/_transcripts/113.vtt
@@ -1,0 +1,501 @@
+WEBVTT
+
+1
+00:00:00.000 --> 00:00:05.000
+Imagine this scenario. You were live streaming your AWS application build on Twitch,
+
+2
+00:00:05.000 --> 00:00:09.280
+and because you are amazing and people love you, you have thousands of people that are watching you,
+
+3
+00:00:09.280 --> 00:00:11.000
+and everything is going great.
+
+4
+00:00:11.000 --> 00:00:15.680
+Then for a split second, you accidentally show your audience your environment variables,
+
+5
+00:00:15.680 --> 00:00:19.880
+and that includes amazing things like your temporary AWS role credentials,
+
+6
+00:00:19.880 --> 00:00:26.160
+like access key, AD, secret access key, and session token, which is basically everything, right?
+
+7
+00:00:26.320 --> 00:00:31.240
+And you start to be worried, your heart is racing, and you are sweating, and you are wondering,
+
+8
+00:00:31.240 --> 00:00:35.520
+okay, what do I do now? Because in a matter of minutes or seconds,
+
+9
+00:00:35.520 --> 00:00:40.960
+people are going to actually try to use these credentials to do something nasty with my AWS account.
+
+10
+00:00:40.960 --> 00:00:46.480
+So what do you do now? Fear not, because today we're going to give you a super quick tip
+
+11
+00:00:46.480 --> 00:00:52.360
+on how to revoke AWS credentials. And by the way, if you're thinking that you want to get the AWS Solution
+
+12
+00:00:52.400 --> 00:00:56.200
+and you want to get an architect certification exam, this is one of the questions that might come up.
+
+13
+00:00:56.200 --> 00:01:02.800
+So be ready to take notes. My name is Luciano, and I'm here with Eoin for another AWS Bites podcast episode.
+
+14
+00:01:11.000 --> 00:01:16.000
+AWS Bites is brought to you by fourTheorem, an AWS consulting partner that doesn't suck,
+
+15
+00:01:16.000 --> 00:01:21.360
+or rarely suck at least. So if you want to check us out, go to fourTheorem.com,
+
+16
+00:01:21.360 --> 00:01:25.840
+and also feel free to reach out to us. We have all the links in the show notes.
+
+17
+00:01:25.840 --> 00:01:30.240
+Okay, let's talk this through. Maybe you have been following our 100-plus episodes,
+
+18
+00:01:30.240 --> 00:01:32.920
+so you know that you shouldn't be using hardcoded credentials.
+
+19
+00:01:32.920 --> 00:01:37.160
+You should be using temporary credentials. Still, you can make a simple mistake,
+
+20
+00:01:37.160 --> 00:01:41.920
+and you can still accidentally commit them to Git, or maybe if you're doing a screen share
+
+21
+00:01:41.920 --> 00:01:47.760
+during a video call, you can still leak them. So what is the problem here, right?
+
+22
+00:01:47.760 --> 00:01:51.880
+Is that a big deal? Because temporary credentials, as the name suggests,
+
+23
+00:01:51.880 --> 00:01:55.280
+is something that's going to be temporary, but how long are they going to last?
+
+24
+00:01:55.280 --> 00:01:59.520
+They might last hours, right? So is that going to be a problem?
+
+25
+00:01:59.520 --> 00:02:03.640
+Well, probably yes, right? Because if you have hours, there is still a lot of damage
+
+26
+00:02:03.640 --> 00:02:09.720
+that you can do in a few hours, especially if that role is something that has very broad credentials.
+
+27
+00:02:09.720 --> 00:02:14.080
+Maybe, I don't know, it's an administrative credential, probably is the worst use case,
+
+28
+00:02:14.080 --> 00:02:17.240
+but you might have a role, for instance, that you use for deployment reasons,
+
+29
+00:02:17.240 --> 00:02:22.400
+so you might be able to provision new Lambdas or EC2s or create VPCs,
+
+30
+00:02:22.400 --> 00:02:27.240
+all things that can lead to actually giving pretty broad permissions to an attacker
+
+31
+00:02:27.240 --> 00:02:30.040
+that might be able to get those credentials.
+
+32
+00:02:30.040 --> 00:02:36.040
+So what do you do in this case? Because the first worry that you have is that
+
+33
+00:02:36.040 --> 00:02:39.920
+you might have a massive AWS bill if somebody tries to use these credentials,
+
+34
+00:02:39.920 --> 00:02:44.920
+and they can do other kinds of damage that might affect the reputation of a company
+
+35
+00:02:44.920 --> 00:02:48.560
+or might destroy some of your environments that you use for work.
+
+36
+00:02:48.560 --> 00:02:51.760
+So yes, what do we do here now, right?
+
+37
+00:02:51.760 --> 00:02:57.240
+And the first thing that you might realize is that this kind of credentials cannot be invalidated.
+
+38
+00:02:57.240 --> 00:03:03.320
+You don't really have an API or a panel where you can say, well, invalidate this particular set of credentials,
+
+39
+00:03:03.320 --> 00:03:05.640
+as you can do with the un-coded ones.
+
+40
+00:03:05.640 --> 00:03:10.880
+So the only thing it seems that we have at end is the expiration time,
+
+41
+00:03:10.880 --> 00:03:14.400
+but we don't want to trust that because it's still pretty open.
+
+42
+00:03:14.400 --> 00:03:16.960
+So what do we do now, Eoin? Any idea?
+
+43
+00:03:18.560 --> 00:03:22.360
+Yeah, like you say, you can't invalidate them, they exist until they expire.
+
+44
+00:03:22.360 --> 00:03:28.440
+So you need to think about what permissions really these credentials are granting
+
+45
+00:03:28.440 --> 00:03:30.960
+and how can you change the permissions level.
+
+46
+00:03:30.960 --> 00:03:34.720
+And still, the valid credentials will still be usable,
+
+47
+00:03:34.720 --> 00:03:41.520
+but maybe just prevent what they can do with those credentials in the time until the expiration occurs.
+
+48
+00:03:41.520 --> 00:03:45.080
+So the only thing you can do really is change the role and the policies within it.
+
+49
+00:03:45.080 --> 00:03:49.640
+I suppose you could delete the role, that would be a brute force way of dealing with the problem.
+
+50
+00:03:49.640 --> 00:03:53.760
+Or you can also update the role and maybe just remove all of its permission,
+
+51
+00:03:53.760 --> 00:03:56.160
+so it doesn't have any permissions then.
+
+52
+00:03:56.160 --> 00:04:01.760
+This would have the immediate effect of blocking out anyone with the temporary credentials.
+
+53
+00:04:01.760 --> 00:04:07.600
+Actually, I say immediate effect, you should also be aware that IAM is eventually consistent.
+
+54
+00:04:07.600 --> 00:04:12.880
+So it might take seconds or even minutes sometimes for the effect of your changes to occur.
+
+55
+00:04:12.880 --> 00:04:19.880
+That's something you don't really control, because IAM has to be reflected out in all of the regions
+
+56
+00:04:19.880 --> 00:04:24.800
+and all of the nodes it's distributed across all of AWS's massive infrastructure.
+
+57
+00:04:24.800 --> 00:04:28.680
+And that doesn't happen in the blink of an eye.
+
+58
+00:04:29.680 --> 00:04:35.120
+So by doing that, you've blocked out your attacker, but it also has side effects,
+
+59
+00:04:35.120 --> 00:04:39.600
+you might not want any valid holders of credentials are also blocked out,
+
+60
+00:04:39.600 --> 00:04:44.360
+including anyone who just gets new credentials for the role after you've made that change.
+
+61
+00:04:44.360 --> 00:04:46.280
+So it's not ideal.
+
+62
+00:04:46.280 --> 00:04:49.680
+You could also attach a policy with an explicit deny.
+
+63
+00:04:49.680 --> 00:04:54.360
+So you could say, deny everything on every resource, and just attach that to the policy.
+
+64
+00:04:54.360 --> 00:04:59.960
+And we know that an explicit deny always wins in these policies, it will trump everything.
+
+65
+00:04:59.960 --> 00:05:02.760
+And it's better because you don't have to remove all the other permissions,
+
+66
+00:05:02.760 --> 00:05:09.160
+you don't have to delete the role, but it still has that problem that it blocks out valid identities too.
+
+67
+00:05:09.160 --> 00:05:14.840
+So the solution to this really is to attach a policy with a conditional deny.
+
+68
+00:05:14.840 --> 00:05:19.760
+And there's a special clever condition that you can use that denies access to identities
+
+69
+00:05:19.760 --> 00:05:23.520
+that assume the role before a specific timestamp.
+
+70
+00:05:23.520 --> 00:05:31.720
+And this is basically a way of saying, deny everybody who assumed this role before the current timestamp right now.
+
+71
+00:05:31.720 --> 00:05:37.280
+And there's a condition key called date less than the condition predicate.
+
+72
+00:05:37.280 --> 00:05:42.520
+And then the attribute you're putting into that predicate is the AWS token issue time.
+
+73
+00:05:42.520 --> 00:05:47.880
+So if the token issue time is less than the current timestamp, then deny them everything.
+
+74
+00:05:47.880 --> 00:05:57.320
+What that means is that valid and invalid, like spurious attackers have no permissions for all sessions until the current time.
+
+75
+00:05:57.320 --> 00:06:00.800
+But it does allow valid users to get a new session.
+
+76
+00:06:00.800 --> 00:06:04.280
+And the new session will be valid and will continue to work.
+
+77
+00:06:04.280 --> 00:06:07.000
+And business will operate as normal.
+
+78
+00:06:07.000 --> 00:06:13.480
+Or if it's a service linked, a service role, then the service can get a new role as well.
+
+79
+00:06:13.480 --> 00:06:15.760
+And the session will be valid.
+
+80
+00:06:15.760 --> 00:06:17.680
+But anyone with the leaked credentials is locked out.
+
+81
+00:06:17.680 --> 00:06:19.680
+So that's your problem solved.
+
+82
+00:06:19.680 --> 00:06:23.440
+Yeah, all of this, the way we've described it, it sounds a bit complicated.
+
+83
+00:06:23.440 --> 00:06:28.080
+And if you're in a situation where you're panicked, it's difficult to remember it all and do it correctly.
+
+84
+00:06:28.080 --> 00:06:33.080
+So how do we simplify this process so we don't have to remember everything in that real situation?
+
+85
+00:06:33.080 --> 00:06:35.800
+So you described already that the policy very well.
+
+86
+00:06:35.800 --> 00:06:38.560
+Anyway, we're going to make that policy available in a gist.
+
+87
+00:06:38.560 --> 00:06:43.800
+And you will find the link in the show notes just if you want to have a more easy to follow reference.
+
+88
+00:06:43.800 --> 00:06:47.040
+And also if you need to copy paste the structure of it.
+
+89
+00:06:47.040 --> 00:06:52.080
+But of course, if you need to remember it from scratch, from the top of your mind, and you're panicking,
+
+90
+00:06:52.080 --> 00:06:54.560
+it might not be the easiest thing to do ever.
+
+91
+00:06:54.560 --> 00:06:58.400
+But luckily, there is a feature which is built in the AWS console.
+
+92
+00:06:58.400 --> 00:07:10.440
+And basically, if you go to your role in IAM, in the page for that specific role, you can select the there is an item called revoke session.
+
+93
+00:07:10.440 --> 00:07:15.560
+And that revoke session will give you something like revoke active sessions.
+
+94
+00:07:15.560 --> 00:07:23.840
+And this will actually do something very similar to what we described, because it's going to create an inline policy called AWS revoke all the sessions,
+
+95
+00:07:23.840 --> 00:07:27.640
+and it's going to inject the current time into that condition.
+
+96
+00:07:27.640 --> 00:07:33.400
+And we also going to have a link in the show notes that basically document this particular feature.
+
+97
+00:07:33.400 --> 00:07:37.320
+But it pretty much works in a similar way to what we described.
+
+98
+00:07:37.320 --> 00:07:47.160
+So while this is something that is good to have available in the AWS console, is it's good to know how it works under the wood.
+
+99
+00:07:47.160 --> 00:07:57.320
+So it's something that if you ever want to automate with your own script, or maybe you want to add, I don't know, something that you can easily do from a CLI or a lambda,
+
+100
+00:07:57.320 --> 00:08:03.240
+because it's maybe easier for you to trigger it that way, you can recreate that feature by yourself.
+
+101
+00:08:04.240 --> 00:08:10.840
+Now, that was the answer for temporary credentials. What about if you have long lived credentials? What do we do?
+
+102
+00:08:10.840 --> 00:08:18.720
+Do we try not to use them? But we know that the reality they are often something that exists in companies and deployments.
+
+103
+00:08:18.720 --> 00:08:20.560
+So what can we do in those cases?
+
+104
+00:08:21.920 --> 00:08:27.880
+The fact that it's harder to do this with long lived credentials is one of the reasons why you should avoid them all together.
+
+105
+00:08:28.120 --> 00:08:34.600
+Because your only option is to just deactivate that access key and create a new one.
+
+106
+00:08:34.600 --> 00:08:43.600
+So it's like a revocation, but if you have long lived credentials, by their nature, that probably means that they're hard coded in multiple places,
+
+107
+00:08:43.600 --> 00:08:53.880
+then you have to go updating those places. And that might mean you're updating an application, there might be some downtime involved or a period where the application isn't working fully.
+
+108
+00:08:53.880 --> 00:09:03.680
+So I would say avoid them if possible. But basically, your only option is to delete the access key, and recreate a new one and update any references to it.
+
+109
+00:09:03.680 --> 00:09:13.680
+That would go for IAM user access keys, but also dreaded root user access keys as well, which hopefully you shouldn't have.
+
+110
+00:09:14.680 --> 00:09:20.560
+There are some organizations that are still using HashiCorp Vault to manage AWS secrets.
+
+111
+00:09:20.560 --> 00:09:28.680
+And I suppose it's worth mentioning because it sometimes uses long lived secrets under the hood, but they're not really long lived in the same sense,
+
+112
+00:09:28.680 --> 00:09:37.280
+because Vault is managing the lifecycle of those secrets for you, and is able to rotate them and revoke them automatically.
+
+113
+00:09:37.280 --> 00:09:44.200
+So it's not much of an issue there, you're just relying on Vault to deliver that feature for you and manage your security.
+
+114
+00:09:44.200 --> 00:09:53.520
+So if you're worried about us complaining about long lived credentials, but you're using Vault, don't worry, as long as you're following the best practices. I don't think there's much of an issue there.
+
+115
+00:09:53.520 --> 00:10:01.160
+This brings us to the end of this short episode, I hope that now you have a little bit more peace of mind that even if you accidentally leak your credentials,
+
+116
+00:10:01.160 --> 00:10:07.960
+at least you know what to do and where you can find some kind of solutions to remediate quickly for that particular issue.
+
+117
+00:10:08.000 --> 00:10:19.720
+It's important, of course, to think about if those credentials are part of an application, if you can guarantee zero downtime to that application while you are revoking the credentials.
+
+118
+00:10:19.720 --> 00:10:25.480
+It's, of course, something you should be doing, but it's not always possible if you're using long lived credentials.
+
+119
+00:10:25.480 --> 00:10:34.840
+So just keep that in mind. And maybe one more reason to think, am I using long lived credentials? Do I really need to use them? Maybe I can transition to temporary credentials.
+
+120
+00:10:34.880 --> 00:10:43.760
+That's probably going to be a good thing to do anyway. So if you have other tips about how to rotate credentials, or if you have any horror story that happened to you,
+
+121
+00:10:43.760 --> 00:10:50.200
+maybe you leaked credentials and something funny or not so funny happened to you after that, it might be interesting to know.
+
+122
+00:10:50.200 --> 00:10:59.920
+It might be a nice story, might teach us something that we didn't know about. So please share all of that stuff either in the comments or if you don't feel like particularly happy to share this stuff publicly,
+
+123
+00:10:59.920 --> 00:11:05.760
+you can always reach out in private and we can have a nice conversation about that and maybe learn from each other.
+
+124
+00:11:05.760 --> 00:11:15.040
+So that's all we have for today. Thank you very much for following along. If you found value, always remember to share or like. This stuff always helps a little bit.
+
+125
+00:11:15.040 --> 00:11:18.520
+So thank you for that and we'll see you in the next episode.


### PR DESCRIPTION

# Transcript

This change includes the transcript for the podcast episode, created by [Podwhisperer](https://github.com/fourTheorem/podwhisperer).
The summary below is generated by [Episoder](https://github.com/fourTheorem/episoder).

## Episode Summary

In this episode, we discuss what to do if you accidentally leak your AWS credentials during a live stream. We explain the difference between temporary credentials and long-lived credentials, and how to revoke each type. For temporary credentials, we recommend using the AWS console to revoke sessions or creating an IAM policy to deny access. For long-lived credentials, you must deactivate and rotate the credentials. We also touch on using tools like HashiCorp Vault to manage credentials securely.

## Suggested Chapters
00:00 Introduction to the scenario of accidentally leaking credentials during a live stream.
00:56 Hosts introduce themselves and the podcast.
01:55 Discussing why leaked temporary credentials can still do damage before they expire.
02:51 Explaining you cannot directly invalidate temporary credentials like you can access keys.
03:18 The only option is to modify the IAM role permissions for the temporary credentials.
06:33 AWS provides a console option to revoke sessions that does this for you.
08:04 For leaked long-lived credentials like access keys, you must deactivate and rotate them.
09:14 Tools like HashiCorp Vault rotate credentials automatically under the hood.
09:53 Conclusion and call to avoid long-lived credentials when possible.

## Suggested Tags
AWS, Cloud, IAM, Credentials, Access Keys, STS, AssumeRole, Temporary Credentials, Revoke, Rotate, Live Stream, Twitch, HashiCorp Vault, Security, Best Practices
