### PR TITLE
add episode 116 transcript

### DIFF
--- a/src/_transcripts/116.json
+++ b/src/_transcripts/116.json
@@ -1,878 +1,878 @@
 {
   "speakers": {
-    "spk_0": "spk_0",
-    "spk_1": "spk_1"
+    "spk_0": "Eoin",
+    "spk_1": "Luciano"
   },
   "segments": [
     {
       "speakerLabel": "spk_0",
       "start": 0,
       "end": 4.72,
-      "text": " Sharing is caring and if you are following the current best practices of using multiple AWS"
+      "text": "Sharing is caring and if you are following the current best practices of using multiple AWS"
     },
     {
       "speakerLabel": "spk_0",
       "start": 4.72,
       "end": 9.200000000000001,
-      "text": " accounts, you'll end up having to share resources between accounts. For some things, you might be"
+      "text": "accounts, you'll end up having to share resources between accounts. For some things, you might be"
     },
     {
       "speakerLabel": "spk_0",
       "start": 9.200000000000001,
       "end": 14.64,
-      "text": " able to use resource-based policies to grant access or assume a role in the target account."
+      "text": "able to use resource-based policies to grant access or assume a role in the target account."
     },
     {
       "speakerLabel": "spk_0",
       "start": 14.64,
       "end": 19.92,
-      "text": " This isn't suitable for everything, however, but luckily there is another way. Today, we are going"
+      "text": "This isn't suitable for everything, however, but luckily there is another way. Today, we are going"
     },
     {
       "speakerLabel": "spk_0",
       "start": 19.92,
       "end": 24.96,
-      "text": " to chat about Resource Access Manager and by the end of the episode, you should know what it does"
+      "text": "to chat about Resource Access Manager and by the end of the episode, you should know what it does"
     },
     {
       "speakerLabel": "spk_0",
       "start": 25.04,
       "end": 30.16,
-      "text": " and how to use it. I'm Eoin, as always, I'm here with Luciano and this is AWS Bites."
+      "text": "and how to use it. I'm Eoin, as always, I'm here with Luciano and this is AWS Bites."
     },
     {
       "speakerLabel": "spk_0",
       "start": 38.24,
       "end": 43.68,
-      "text": " AWS Bites is brought to you by fourTheorem, the AWS partner who works with you to build successful"
+      "text": "AWS Bites is brought to you by fourTheorem, the AWS partner who works with you to build successful"
     },
     {
       "speakerLabel": "spk_0",
       "start": 43.68,
       "end": 49.92,
-      "text": " projects in the cloud. Check us out at fortherem.com. Luciano, maybe you can start and tell us all"
+      "text": "projects in the cloud. Check us out at fourtherem.com. Luciano, maybe you can start and tell us all"
     },
     {
       "speakerLabel": "spk_0",
       "start": 50.480000000000004,
       "end": 53.84,
-      "text": " what kind of problems is Resource Access Manager designed to solve?"
+      "text": "what kind of problems is Resource Access Manager designed to solve?"
     },
     {
       "speakerLabel": "spk_0",
       "start": 53.84,
       "end": 60.480000000000004,
-      "text": " Yes."
+      "text": "Yes."
     },
     {
       "speakerLabel": "spk_1",
       "start": 60.480000000000004,
       "end": 65.52000000000001,
-      "text": " So AWS Resource Access Manager or RAM, which is not to be confused with random access memory, by the way, it's the same acronym. So this is a tool that is designed to solve the problem of"
+      "text": "So AWS Resource Access Manager or RAM, which is not to be confused with random access memory, by the way, it's the same acronym. So this is a tool that is designed to solve the problem of"
     },
     {
       "speakerLabel": "spk_1",
       "start": 65.52000000000001,
       "end": 71.92,
-      "text": " securely sharing AWS resources across different AWS accounts within an organization or even with"
+      "text": "securely sharing AWS resources across different AWS accounts within an organization or even with"
     },
     {
       "speakerLabel": "spk_1",
       "start": 71.92,
       "end": 78.32000000000001,
-      "text": " external organizations. It is basically designed to do this while it tries to reduce the cost"
+      "text": "external organizations. It is basically designed to do this while it tries to reduce the cost"
     },
     {
       "speakerLabel": "spk_1",
       "start": 78.32,
       "end": 83.36,
-      "text": " by eliminating, for instance, resource duplications. You can simplify centralized"
+      "text": "by eliminating, for instance, resource duplications. You can simplify centralized"
     },
     {
       "speakerLabel": "spk_1",
       "start": 83.36,
       "end": 88.32,
-      "text": " access to resources and it can achieve security and compliance. So RAM allows you to share"
+      "text": "access to resources and it can achieve security and compliance. So RAM allows you to share"
     },
     {
       "speakerLabel": "spk_1",
       "start": 88.32,
       "end": 94.88,
-      "text": " resources with, as I said, AWS accounts, including the ones outside or inside the organization."
+      "text": "resources with, as I said, AWS accounts, including the ones outside or inside the organization."
     },
     {
       "speakerLabel": "spk_1",
       "start": 94.88,
       "end": 99.11999999999999,
-      "text": " It can also share resources with accounts in a specific organization. So depending on the resource"
+      "text": "It can also share resources with accounts in a specific organization. So depending on the resource"
     },
     {
       "speakerLabel": "spk_1",
       "start": 99.11999999999999,
       "end": 104.96,
-      "text": " type, you can share things with, for instance, the organization itself and organization units with"
+      "text": "type, you can share things with, for instance, the organization itself and organization units with"
     },
     {
       "speakerLabel": "spk_1",
       "start": 104.96,
       "end": 110.47999999999999,
-      "text": " all the accounts inside of it or specific accounts. And you can also share resources with"
+      "text": "all the accounts inside of it or specific accounts. And you can also share resources with"
     },
     {
       "speakerLabel": "spk_1",
       "start": 110.47999999999999,
       "end": 115.91999999999999,
-      "text": " identities like users, roles. The pricing is interesting because effectively there is no"
+      "text": "identities like users, roles. The pricing is interesting because effectively there is no"
     },
     {
       "speakerLabel": "spk_1",
       "start": 115.91999999999999,
       "end": 121.6,
-      "text": " additional costs. You only pay for the services that you are actually sharing. So you are creating"
+      "text": "additional costs. You only pay for the services that you are actually sharing. So you are creating"
     },
     {
       "speakerLabel": "spk_1",
       "start": 121.6,
       "end": 127.36,
-      "text": " resources that you share and you're going to be paying for those resources. Now, what are some of"
+      "text": "resources that you share and you're going to be paying for those resources. Now, what are some of"
     },
     {
       "speakerLabel": "spk_1",
       "start": 127.36,
       "end": 133.68,
-      "text": " the use cases? The most common one you're likely to come across with RAM is VPC subnet sharing."
+      "text": "the use cases? The most common one you're likely to come across with RAM is VPC subnet sharing."
     },
     {
       "speakerLabel": "spk_0",
       "start": 133.68,
       "end": 139.6,
-      "text": " Now, before Resource Access Manager, VPCs in different accounts, if you wanted to share them,"
+      "text": "Now, before Resource Access Manager, VPCs in different accounts, if you wanted to share them,"
     },
     {
       "speakerLabel": "spk_0",
       "start": 139.6,
       "end": 145.12,
-      "text": " it generally meant using something like VPC peering or transit gateway. If you share subnets"
+      "text": "it generally meant using something like VPC peering or transit gateway. If you share subnets"
     },
     {
       "speakerLabel": "spk_0",
       "start": 145.12,
       "end": 152.24,
-      "text": " in a VPC with RAM accounts, then get access to implicit routing in that VPC. So if you have a"
+      "text": "in a VPC with RAM accounts, then get access to implicit routing in that VPC. So if you have a"
     },
     {
       "speakerLabel": "spk_0",
       "start": 152.24,
       "end": 157.44,
-      "text": " VPC in the owner account, you share it with participants and participating accounts, then"
+      "text": "VPC in the owner account, you share it with participants and participating accounts, then"
     },
     {
       "speakerLabel": "spk_0",
       "start": 157.44,
       "end": 163.36,
-      "text": " they can use that subnet and it allows them to implicitly route within other resources already"
+      "text": "they can use that subnet and it allows them to implicitly route within other resources already"
     },
     {
       "speakerLabel": "spk_0",
       "start": 163.36,
       "end": 168.8,
-      "text": " in that VPC. The IP address allocation then within the centrally managed subnets"
+      "text": "in that VPC. The IP address allocation then within the centrally managed subnets"
     },
     {
       "speakerLabel": "spk_0",
       "start": 168.8,
       "end": 175.36,
-      "text": " can be managed by a network team. So that's one of the advantages of this shared services VPC model."
+      "text": "can be managed by a network team. So that's one of the advantages of this shared services VPC model."
     },
     {
       "speakerLabel": "spk_0",
       "start": 175.36,
       "end": 181.20000000000002,
-      "text": " Accounts with access to the shared resource then can access databases or VPC endpoints or other"
+      "text": "Accounts with access to the shared resource then can access databases or VPC endpoints or other"
     },
     {
       "speakerLabel": "spk_0",
       "start": 181.20000000000002,
       "end": 187.44000000000003,
-      "text": " servers running in the subnets. So how does it work? Well, if you've got this shared services"
+      "text": "servers running in the subnets. So how does it work? Well, if you've got this shared services"
     },
     {
       "speakerLabel": "spk_0",
       "start": 187.44000000000003,
       "end": 193.04000000000002,
-      "text": " account, you create your VPCs and subnets in it, then you share the subnets with other accounts."
+      "text": "account, you create your VPCs and subnets in it, then you share the subnets with other accounts."
     },
     {
       "speakerLabel": "spk_0",
       "start": 193.36,
       "end": 198.72000000000003,
-      "text": " Within an organization and participants can then see those shared subnets in their account."
+      "text": "Within an organization and participants can then see those shared subnets in their account."
     },
     {
       "speakerLabel": "spk_0",
       "start": 198.72000000000003,
       "end": 205.04000000000002,
-      "text": " Now let's go back to the resource owner account. If they start an EC2 instance in the shared VPC,"
+      "text": "Now let's go back to the resource owner account. If they start an EC2 instance in the shared VPC,"
     },
     {
       "speakerLabel": "spk_0",
       "start": 205.04000000000002,
       "end": 209.36,
-      "text": " only they can see it. You're not sharing all of the things in the subnet per se."
+      "text": "only they can see it. You're not sharing all of the things in the subnet per se."
     },
     {
       "speakerLabel": "spk_0",
       "start": 210.08,
       "end": 215.28000000000003,
-      "text": " Participants can't make networking changes. So only the owner can make changes to the subnets,"
+      "text": "Participants can't make networking changes. So only the owner can make changes to the subnets,"
     },
     {
       "speakerLabel": "spk_0",
       "start": 215.84,
       "end": 221.52,
-      "text": " but participants can provision resources they own into shared subnets. Like they can start"
+      "text": "but participants can provision resources they own into shared subnets. Like they can start"
     },
     {
       "speakerLabel": "spk_0",
       "start": 221.52,
       "end": 227.52,
-      "text": " their own EC2 instances in the account in the shared subnet. The participant will then own the"
+      "text": "their own EC2 instances in the account in the shared subnet. The participant will then own the"
     },
     {
       "speakerLabel": "spk_0",
       "start": 227.52,
       "end": 234.88,
-      "text": " EC2 instance, even though the shared owner account owns the subnet. I suppose it's worth saying that"
+      "text": "EC2 instance, even though the shared owner account owns the subnet. I suppose it's worth saying that"
     },
     {
       "speakerLabel": "spk_0",
       "start": 234.88,
       "end": 239.44,
-      "text": " sharing subnets is very different solution to using VPC peering and Transit Gateway."
+      "text": "sharing subnets is very different solution to using VPC peering and Transit Gateway."
     },
     {
       "speakerLabel": "spk_0",
       "start": 239.44,
       "end": 244.56,
-      "text": " And you might use them in combination actually, because sharing with RAM means that you have"
+      "text": "And you might use them in combination actually, because sharing with RAM means that you have"
     },
     {
       "speakerLabel": "spk_0",
       "start": 244.56,
       "end": 249.68,
-      "text": " access to an existing subnet. It doesn't really provide any additional routing. It just allows"
+      "text": "access to an existing subnet. It doesn't really provide any additional routing. It just allows"
     },
     {
       "speakerLabel": "spk_0",
       "start": 249.68,
       "end": 255.04000000000002,
-      "text": " you to launch resources into existing subnets. If you wanted to have routing into this shared"
+      "text": "you to launch resources into existing subnets. If you wanted to have routing into this shared"
     },
     {
       "speakerLabel": "spk_0",
       "start": 255.04000000000002,
       "end": 261.36,
-      "text": " services VPC, you still need to do something like VPC peering or use Transit Gateway to route from"
+      "text": "services VPC, you still need to do something like VPC peering or use Transit Gateway to route from"
     },
     {
       "speakerLabel": "spk_0",
       "start": 261.36,
       "end": 267.36,
-      "text": " one VPC to another, just like you do between any two VPCs. So RAM is not a routing solution,"
+      "text": "one VPC to another, just like you do between any two VPCs. So RAM is not a routing solution,"
     },
     {
       "speakerLabel": "spk_0",
       "start": 268.4,
       "end": 273.04,
-      "text": " and that's something to be aware of, but you can combine it with things like Transit Gateway and"
+      "text": "and that's something to be aware of, but you can combine it with things like Transit Gateway and"
     },
     {
       "speakerLabel": "spk_0",
       "start": 273.04,
       "end": 278.72,
-      "text": " peering. So that's the most common use case, I think, VPC sharing. Apart from networking,"
+      "text": "peering. So that's the most common use case, I think, VPC sharing. Apart from networking,"
     },
     {
       "speakerLabel": "spk_0",
       "start": 278.72,
       "end": 283.44000000000005,
-      "text": " there are many other things you can share with RAM. AppSync APIs are one thing. There's code"
+      "text": "there are many other things you can share with RAM. AppSync APIs are one thing. There's code"
     },
     {
       "speakerLabel": "spk_0",
       "start": 283.44000000000005,
       "end": 288.48,
-      "text": " build projects. You can share capacity reservations, which is interesting for"
+      "text": "build projects. You can share capacity reservations, which is interesting for"
     },
     {
       "speakerLabel": "spk_0",
       "start": 288.48,
       "end": 295.12,
-      "text": " optimizing compute capacity costs. You can share FSX volumes. You can share GLUE catalogs, tables,"
+      "text": "optimizing compute capacity costs. You can share FSX volumes. You can share GLUE catalogs, tables,"
     },
     {
       "speakerLabel": "spk_0",
       "start": 295.12,
       "end": 302.96000000000004,
-      "text": " and databases. So if you've got these catalogs in GLUE for access to data on S3, you can share it"
+      "text": "and databases. So if you've got these catalogs in GLUE for access to data on S3, you can share it"
     },
     {
       "speakerLabel": "spk_0",
       "start": 302.96000000000004,
       "end": 307.68,
-      "text": " this way rather than having to duplicate those resources in many accounts. If you have a private"
+      "text": "this way rather than having to duplicate those resources in many accounts. If you have a private"
     },
     {
       "speakerLabel": "spk_0",
       "start": 307.68,
       "end": 313.36,
-      "text": " certificate authority with the AWS Private CA, you can share that too. One of the things that"
+      "text": "certificate authority with the AWS Private CA, you can share that too. One of the things that"
     },
     {
       "speakerLabel": "spk_0",
       "start": 313.36,
       "end": 319.04,
-      "text": " one of our colleagues, Connor, wrote an article about was using RAM to share Aurora databases."
+      "text": "one of our colleagues, Connor, wrote an article about was using RAM to share Aurora databases."
     },
     {
       "speakerLabel": "spk_0",
       "start": 319.04,
       "end": 322.72,
-      "text": " So he has a really good blog post on that. We're going to link that in the show notes."
+      "text": "So he has a really good blog post on that. We're going to link that in the show notes."
     },
     {
       "speakerLabel": "spk_0",
       "start": 322.72,
       "end": 329.52,
-      "text": " Another topic for where we wrote a blog was VPC lattice. And VPC lattice is a really cool topic."
+      "text": "Another topic for where we wrote a blog was VPC lattice. And VPC lattice is a really cool topic."
     },
     {
       "speakerLabel": "spk_0",
       "start": 329.52,
       "end": 333.92,
-      "text": " And if you haven't discovered it or haven't seen our previous episode, I'd recommend you check it"
+      "text": "And if you haven't discovered it or haven't seen our previous episode, I'd recommend you check it"
     },
     {
       "speakerLabel": "spk_0",
       "start": 333.92,
       "end": 340.40000000000003,
-      "text": " out because it leverages RAM highly to share services and service networks. We have the episode"
+      "text": "out because it leverages RAM highly to share services and service networks. We have the episode"
     },
     {
       "speakerLabel": "spk_0",
       "start": 340.40000000000003,
       "end": 344.56,
-      "text": " on that. We have a blog post, and we have a sample application code. And the links for all three will"
+      "text": "on that. We have a blog post, and we have a sample application code. And the links for all three will"
     },
     {
       "speakerLabel": "spk_0",
       "start": 344.56,
       "end": 350,
-      "text": " be in the show notes. Transit gateways themselves are things you can share with RAM. And hot off the"
+      "text": "be in the show notes. Transit gateways themselves are things you can share with RAM. And hot off the"
     },
     {
       "speakerLabel": "spk_0",
       "start": 350,
       "end": 356.32,
-      "text": " press, there is a new resource since last week only, I believe, which is sharing Systems Manager"
+      "text": "press, there is a new resource since last week only, I believe, which is sharing Systems Manager"
     },
     {
       "speakerLabel": "spk_0",
       "start": 356.32,
       "end": 362.16,
-      "text": " Parameter Store parameters, otherwise known as SSM parameters. This is something which people have"
+      "text": "Parameter Store parameters, otherwise known as SSM parameters. This is something which people have"
     },
     {
       "speakerLabel": "spk_0",
       "start": 362.16,
       "end": 366.40000000000003,
-      "text": " been very excited about to hear because previously, you would really have to replicate those"
+      "text": "been very excited about to hear because previously, you would really have to replicate those"
     },
     {
       "speakerLabel": "spk_0",
       "start": 366.40000000000003,
       "end": 371.20000000000005,
-      "text": " parameters. And there wasn't any way to share them across account. Now, if you've got parameters,"
+      "text": "parameters. And there wasn't any way to share them across account. Now, if you've got parameters,"
     },
     {
       "speakerLabel": "spk_0",
       "start": 371.20000000000005,
       "end": 378,
-      "text": " let's say for custom AMI for an EC2 instance, and you want to share that across multiple accounts,"
+      "text": "let's say for custom AMI for an EC2 instance, and you want to share that across multiple accounts,"
     },
     {
       "speakerLabel": "spk_0",
       "start": 378,
       "end": 383.52000000000004,
-      "text": " everybody can discover the latest version of the AMI. You can now do that with parameter store."
+      "text": "everybody can discover the latest version of the AMI. You can now do that with parameter store."
     },
     {
       "speakerLabel": "spk_0",
       "start": 383.52000000000004,
       "end": 388.72,
-      "text": " There's a couple of gotchas to know with SSM parameter sharing. It only works for advanced"
+      "text": "There's a couple of gotchas to know with SSM parameter sharing. It only works for advanced"
     },
     {
       "speakerLabel": "spk_0",
       "start": 388.72,
       "end": 393.6,
-      "text": " tier ones. So those are, I'm afraid, the more expensive ones, about $0.05 a month each."
+      "text": "tier ones. So those are, I'm afraid, the more expensive ones, about $0.05 a month each."
     },
     {
       "speakerLabel": "spk_0",
       "start": 394.16,
       "end": 399.04,
-      "text": " It doesn't work for the standard tier, which is the free option. So it definitely seems like AWS"
+      "text": "It doesn't work for the standard tier, which is the free option. So it definitely seems like AWS"
     },
     {
       "speakerLabel": "spk_0",
       "start": 399.04,
       "end": 402.64000000000004,
-      "text": " slipped up in allowing that standard tier to be free. And they're just trying to push all"
+      "text": "slipped up in allowing that standard tier to be free. And they're just trying to push all"
     },
     {
       "speakerLabel": "spk_0",
       "start": 402.64000000000004,
       "end": 406.8,
-      "text": " of the features into the advanced tier from now on as a correction measure."
+      "text": "of the features into the advanced tier from now on as a correction measure."
     },
     {
       "speakerLabel": "spk_0",
       "start": 407.92,
       "end": 411.12,
-      "text": " Yushiano, those are some of the use cases. There are other services you can share with"
+      "text": "Luciano, those are some of the use cases. There are other services you can share with"
     },
     {
       "speakerLabel": "spk_0",
       "start": 411.12,
       "end": 415.12,
-      "text": " RAM. You can check out the full list in the link in the show notes. But let's say people"
+      "text": "RAM. You can check out the full list in the link in the show notes. But let's say people"
     },
     {
       "speakerLabel": "spk_0",
       "start": 415.2,
       "end": 419.44,
-      "text": " want to use it. How do you get started? Yes."
+      "text": "want to use it. How do you get started?"
     },
     {
       "speakerLabel": "spk_1",
       "start": 419.44,
       "end": 425.92,
-      "text": " So there are a few steps that you need to follow. So first of all, you need to create a resource share in Resource Access Manager."
+      "text": "Yes. So there are a few steps that you need to follow. So first of all, you need to create a resource share in Resource Access Manager."
     },
     {
       "speakerLabel": "spk_1",
       "start": 425.92,
       "end": 432.32,
-      "text": " And by default, every account you share with, so you share something with an account, that account"
+      "text": "And by default, every account you share with, so you share something with an account, that account"
     },
     {
       "speakerLabel": "spk_1",
       "start": 432.32,
       "end": 437.12,
-      "text": " receives an invitation. And to avoid this, you can also enable sharing with the entire AWS"
+      "text": "receives an invitation. And to avoid this, you can also enable sharing with the entire AWS"
     },
     {
       "speakerLabel": "spk_1",
       "start": 437.12,
       "end": 443.2,
-      "text": " organization in the AWS Management Console. Normally, owner accounts as full access control"
+      "text": "organization in the AWS Management Console. Normally, owner accounts have full access control"
     },
     {
       "speakerLabel": "spk_1",
       "start": 443.84,
       "end": 448.71999999999997,
-      "text": " and the shared principles have limited subset of permission. So again, it's still the idea that"
+      "text": "and the shared principles have limited subset of permission. So again, it's still the idea that"
     },
     {
       "speakerLabel": "spk_1",
       "start": 448.71999999999997,
       "end": 455.2,
-      "text": " you are not giving up ownership. You are just allowing another account to see those resources"
+      "text": "you are not giving up ownership. You are just allowing another account to see those resources"
     },
     {
       "speakerLabel": "spk_1",
       "start": 455.2,
       "end": 459.12,
-      "text": " and use them in different ways, depending on the type of resource. When you create a share,"
+      "text": "and use them in different ways, depending on the type of resource. When you create a share,"
     },
     {
       "speakerLabel": "spk_1",
       "start": 459.12,
       "end": 463.76,
-      "text": " you need to specify a few different things. First of all, the resource type, for instance,"
+      "text": "you need to specify a few different things. First of all, the resource type, for instance,"
     },
     {
       "speakerLabel": "spk_1",
       "start": 463.76,
       "end": 470.24,
-      "text": " is it a subnet? Is it a blue catalog? Is it an SSM parameter or something else? Then you see the"
+      "text": "is it a subnet? Is it a blue catalog? Is it an SSM parameter or something else? Then you see the"
     },
     {
       "speakerLabel": "spk_1",
       "start": 470.24,
       "end": 475.92,
-      "text": " list of the resources of that type and you can pick the specific resources that you want to share"
+      "text": "list of the resources of that type and you can pick the specific resources that you want to share"
     },
     {
       "speakerLabel": "spk_1",
       "start": 475.92,
       "end": 482.32,
-      "text": " on that list. And then you need to define the permissions that the recipients will get on the"
+      "text": "on that list. And then you need to define the permissions that the recipients will get on the"
     },
     {
       "speakerLabel": "spk_1",
       "start": 482.32,
       "end": 487.76,
-      "text": " resources you have selected. And this will be either AWS Managed Permission or for some resources,"
+      "text": "resources you have selected. And this will be either AWS Managed Permission or for some resources,"
     },
     {
       "speakerLabel": "spk_1",
       "start": 487.76,
       "end": 493.2,
-      "text": " you can even create your own custom managed permissions. Each resource type has different"
+      "text": "you can even create your own custom managed permissions. Each resource type has different"
     },
     {
       "speakerLabel": "spk_1",
       "start": 493.2,
       "end": 498.48,
-      "text": " options for sharing within RAM and the supported options vary depending on the resource type."
+      "text": "options for sharing within RAM and the supported options vary depending on the resource type."
     },
     {
       "speakerLabel": "spk_1",
       "start": 498.48,
       "end": 504.08000000000004,
-      "text": " Options can be things like whether you can share with an account outside the organization or you"
+      "text": "Options can be things like whether you can share with an account outside the organization or you"
     },
     {
       "speakerLabel": "spk_1",
       "start": 504.08000000000004,
       "end": 509.04,
-      "text": " are maybe limited only to the account inside the specific organization. Whether you can share with"
+      "text": "are maybe limited only to the account inside the specific organization. Whether you can share with"
     },
     {
       "speakerLabel": "spk_1",
       "start": 509.04,
       "end": 514.8000000000001,
-      "text": " IAM users and roles, whether you can share with AWS Service Principles or whether you can use"
+      "text": "IAM users and roles, whether you can share with AWS Service Principles or whether you can use"
     },
     {
       "speakerLabel": "spk_1",
       "start": 514.8000000000001,
       "end": 520.4,
-      "text": " custom managed permissions. So again, there is a guided process if you use the AWS Console and as"
+      "text": "custom managed permissions. So again, there is a guided process if you use the AWS Console and as"
     },
     {
       "speakerLabel": "spk_1",
       "start": 520.4,
       "end": 525.2,
-      "text": " you go through, you will see different screens and different options depending on the resources that"
+      "text": "you go through, you will see different screens and different options depending on the resources that"
     },
     {
       "speakerLabel": "spk_1",
       "start": 525.2,
       "end": 530.72,
-      "text": " you have selected. We will link to the documentation for more details just to get a better overview of"
+      "text": "you have selected. We will link to the documentation for more details just to get a better overview of"
     },
     {
       "speakerLabel": "spk_1",
       "start": 530.72,
       "end": 535.44,
-      "text": " what's possible, which resources can be shared and what options are available for every resource."
+      "text": "what's possible, which resources can be shared and what options are available for every resource."
     },
     {
       "speakerLabel": "spk_1",
       "start": 535.44,
       "end": 539.6800000000001,
-      "text": " But just to give you an example, if you want to share a subnet, all of the options that we"
+      "text": "But just to give you an example, if you want to share a subnet, all of the options that we"
     },
     {
       "speakerLabel": "spk_1",
       "start": 539.6800000000001,
       "end": 544.48,
-      "text": " mentioned are not available for this particular resource. What you cannot do, for instance, you"
+      "text": "mentioned are not available for this particular resource. What you cannot do, for instance, you"
     },
     {
       "speakerLabel": "spk_1",
       "start": 544.48,
       "end": 549.76,
-      "text": " cannot share with accounts outside the organization. So if you're sharing a subnet, that's going to be"
+      "text": "cannot share with accounts outside the organization. So if you're sharing a subnet, that's going to be"
     },
     {
       "speakerLabel": "spk_1",
       "start": 549.76,
       "end": 554.24,
-      "text": " available only for the accounts inside your organization. You cannot share a subnet with"
+      "text": "available only for the accounts inside your organization. You cannot share a subnet with"
     },
     {
       "speakerLabel": "spk_1",
       "start": 554.24,
       "end": 560,
-      "text": " specific IAM users and roles, and you cannot share it with Service Principles. And you have to use"
+      "text": "specific IAM users and roles, and you cannot share it with Service Principles. And you have to use"
     },
     {
       "speakerLabel": "spk_1",
       "start": 560,
       "end": 567.2,
-      "text": " default AWS Managed Permissions. So effectively, you can allow participants to launch instances"
+      "text": "default AWS Managed Permissions. So effectively, you can allow participants to launch instances"
     },
     {
       "speakerLabel": "spk_1",
       "start": 567.2,
       "end": 573.12,
-      "text": " within the subnet, create EAPs and things like that that are predefined in AWS. You cannot really"
+      "text": "within the subnet, create EIPs and things like that that are predefined in AWS. You cannot really"
     },
     {
       "speakerLabel": "spk_1",
       "start": 573.12,
       "end": 580.72,
-      "text": " just create your own set of permissions and decide in a fine-grained way what people can do with that subnet."
+      "text": "just create your own set of permissions and decide in a fine-grained way what people can do with that subnet."
     },
     {
       "speakerLabel": "spk_0",
       "start": 580.72,
       "end": 585.6800000000001,
-      "text": " I guess you could, if you wanted to restrict that, use a Service Control Policy. One of the things we"
+      "text": "I guess you could, if you wanted to restrict that, use a Service Control Policy. One of the things we"
     },
     {
       "speakerLabel": "spk_0",
       "start": 585.6800000000001,
       "end": 589.84,
-      "text": " talked about recently, if you wanted to narrow down those permissions, but I don't know what"
+      "text": "talked about recently, if you wanted to narrow down those permissions, but I don't know what"
     },
     {
       "speakerLabel": "spk_0",
       "start": 589.84,
       "end": 594.8000000000001,
-      "text": " your reason for that might be, maybe people can give some suggestions."
+      "text": "your reason for that might be, maybe people can give some suggestions."
     },
     {
       "speakerLabel": "spk_1",
       "start": 594.8000000000001,
       "end": 601.6,
-      "text": " Yeah, that's a really good point. But I guess the next question would be, once you share something from the ownership side,"
+      "text": "Yeah, that's a really good point. But I guess the next question would be, once you share something from the ownership side,"
     },
     {
       "speakerLabel": "spk_1",
       "start": 601.6,
       "end": 606.8000000000001,
-      "text": " so you are sharing from a specific account, what would that look like from the participant side?"
+      "text": "so you are sharing from a specific account, what would that look like from the participant side?"
     },
     {
       "speakerLabel": "spk_1",
       "start": 606.8,
       "end": 612.4,
-      "text": " So whoever is receiving access to that particular resource or set of resources."
+      "text": "So whoever is receiving access to that particular resource or set of resources."
     },
     {
       "speakerLabel": "spk_0",
       "start": 612.4,
       "end": 617.92,
-      "text": " Yeah, so from the participant side, then if you go into RAM, you'll get a complete overview of all the shares and the"
+      "text": "Yeah, so from the participant side, then if you go into RAM, you'll get a complete overview of all the shares and the"
     },
     {
       "speakerLabel": "spk_0",
       "start": 617.92,
       "end": 622.64,
-      "text": " resources shared within your account. So you can see what people have shared with you. And then"
+      "text": "resources shared within your account. So you can see what people have shared with you. And then"
     },
     {
       "speakerLabel": "spk_0",
       "start": 622.64,
       "end": 629.04,
-      "text": " when you go to see specific resources, like if you go into the VPC console, select a subnet, you will"
+      "text": "when you go to see specific resources, like if you go into the VPC console, select a subnet, you will"
     },
     {
       "speakerLabel": "spk_0",
       "start": 629.04,
       "end": 633.4399999999999,
-      "text": " see the owner account column in the table. And you can see that the owner account is a different"
+      "text": "see the owner account column in the table. And you can see that the owner account is a different"
     },
     {
       "speakerLabel": "spk_0",
       "start": 633.44,
       "end": 639.2800000000001,
-      "text": " identifier than your account. And that's how you know it's an externally managed resource. If you"
+      "text": "identifier than your account. And that's how you know it's an externally managed resource. If you"
     },
     {
       "speakerLabel": "spk_0",
       "start": 639.2800000000001,
       "end": 645.12,
-      "text": " share subnets, you can also see the associated VPC in the VPC console, which is maybe a little"
+      "text": "share subnets, you can also see the associated VPC in the VPC console, which is maybe a little"
     },
     {
       "speakerLabel": "spk_0",
       "start": 645.12,
       "end": 651.0400000000001,
-      "text": " bit unexpected, because you haven't explicitly shared the VPC itself. The VPC as a thing is not"
+      "text": "bit unexpected, because you haven't explicitly shared the VPC itself. The VPC as a thing is not"
     },
     {
       "speakerLabel": "spk_0",
       "start": 651.0400000000001,
       "end": 658.4000000000001,
-      "text": " a shareable resource with RAM. And participants can tag resources with separate tags to the shared"
+      "text": "a shareable resource with RAM. And participants can tag resources with separate tags to the shared"
     },
     {
       "speakerLabel": "spk_0",
       "start": 658.4,
       "end": 663.1999999999999,
-      "text": " resource, which is also probably unexpected, because you might expect that tags are an"
+      "text": "resource, which is also probably unexpected, because you might expect that tags are an"
     },
     {
       "speakerLabel": "spk_0",
       "start": 663.1999999999999,
       "end": 668.72,
-      "text": " implicit part of the resource. But tags are almost like a separate resource that's linked to the"
+      "text": "implicit part of the resource. But tags are almost like a separate resource that's linked to the"
     },
     {
       "speakerLabel": "spk_0",
       "start": 668.72,
       "end": 675.28,
-      "text": " subnet itself. So when you share a subnet, you don't share the tags, you can give us new tags in"
+      "text": "subnet itself. So when you share a subnet, you don't share the tags, you can give us new tags in"
     },
     {
       "speakerLabel": "spk_0",
       "start": 675.28,
       "end": 681.1999999999999,
-      "text": " the participant account. Another unexpected thing you might see when you start sharing subnets"
+      "text": "the participant account. Another unexpected thing you might see when you start sharing subnets"
     },
     {
       "speakerLabel": "spk_0",
       "start": 681.2,
       "end": 689.84,
-      "text": " across accounts is that you might share a subnet in US East 1A, right, availability zone. And when"
+      "text": "across accounts is that you might share a subnet in us-east-1a, right, availability zone. And when"
     },
     {
       "speakerLabel": "spk_0",
       "start": 689.84,
       "end": 695.44,
-      "text": " you look at it in the participant account, you might see that it's called US East 1B. And you"
+      "text": "you look at it in the participant account, you might see that it's called us-east-1b. And you"
     },
     {
       "speakerLabel": "spk_0",
       "start": 695.44,
       "end": 700.24,
-      "text": " will wonder what that's all about, and how they seem to have moved from a different data center"
+      "text": "will wonder what that's all about, and how they seem to have moved from a different data center"
     },
     {
       "speakerLabel": "spk_0",
       "start": 700.24,
       "end": 705.2,
-      "text": " to 130 miles away. And the reason for that, you may know, but in case you don't, it's worth"
+      "text": "to one 30 miles away. And the reason for that, you may know, but in case you don't, it's worth"
     },
     {
       "speakerLabel": "spk_0",
       "start": 705.2,
       "end": 712.32,
-      "text": " stating it. When you create a new AWS account, AWS randomly assigns these availability zone labels"
+      "text": "stating it. When you create a new AWS account, AWS randomly assigns these availability zone labels"
     },
     {
       "speakerLabel": "spk_0",
       "start": 712.88,
       "end": 720,
-      "text": " to you in a just in a randomized way. So everybody's US East 1A may be different. And if you"
+      "text": "to you in a just in a randomized way. So everybody's US East 1A may be different. And if you"
     },
     {
       "speakerLabel": "spk_0",
       "start": 720,
       "end": 725.9200000000001,
-      "text": " want to see if they're actually in the same AZ, there's another identifier called the AZ ID. And"
+      "text": "want to see if they're actually in the same AZ, there's another identifier called the AZ ID. And"
     },
     {
       "speakerLabel": "spk_0",
       "start": 725.9200000000001,
       "end": 734.5600000000001,
-      "text": " this has a format like EUW1-AZ2. And these are physical AZ identifiers, and they do not change"
+      "text": "this has a format like EUW1-AZ2. And these are physical AZ identifiers, and they do not change"
     },
     {
       "speakerLabel": "spk_0",
       "start": 734.56,
       "end": 739.28,
-      "text": " per account. So the whole idea with randomizing them is they don't want everybody to just pick"
+      "text": "per account. So the whole idea with randomizing them is they don't want everybody to just pick"
     },
     {
       "speakerLabel": "spk_0",
       "start": 739.28,
       "end": 744.0799999999999,
-      "text": " the first AZ when they're launching something, and then have unbalanced load across their"
+      "text": "the first AZ when they're launching something, and then have unbalanced load across their"
     },
     {
       "speakerLabel": "spk_0",
       "start": 744.0799999999999,
       "end": 750.2399999999999,
-      "text": " availability zones. So that's why to randomize them. If you are using availability zones names,"
+      "text": "availability zones. So that's why to randomize them. If you are using availability zones names,"
     },
     {
       "speakerLabel": "spk_0",
       "start": 750.2399999999999,
       "end": 754.64,
-      "text": " then remember, they don't necessarily line up from account to account. I think one thing you"
+      "text": "then remember, they don't necessarily line up from account to account. I think one thing you"
     },
     {
       "speakerLabel": "spk_0",
       "start": 754.64,
       "end": 759.8399999999999,
-      "text": " mentioned as well Luciano, which is worth highlighting again, is that sharing within an"
+      "text": "mentioned as well Luciano, which is worth highlighting again, is that sharing within an"
     },
     {
       "speakerLabel": "spk_0",
       "start": 759.84,
       "end": 764.32,
-      "text": " organization, if you want to make it easier, in fact, for some resources, you have to do this"
+      "text": "organization, if you want to make it easier, in fact, for some resources, you have to do this"
     },
     {
       "speakerLabel": "spk_0",
       "start": 764.32,
       "end": 770.24,
-      "text": " anyway. So it's probably worthwhile doing it, you just go into RAM in the management account,"
+      "text": "anyway. So it's probably worthwhile doing it, you just go into RAM in the management account,"
     },
     {
       "speakerLabel": "spk_0",
       "start": 770.24,
       "end": 775.2,
-      "text": " and enable sharing inside the organization. And then when you share resources, the acceptance is"
+      "text": "and enable sharing inside the organization. And then when you share resources, the acceptance is"
     },
     {
       "speakerLabel": "spk_0",
       "start": 775.2,
       "end": 780.64,
-      "text": " automatic, the participating accounts don't have to accept an invitation. So I think RAM is pretty"
+      "text": "automatic, the participating accounts don't have to accept an invitation. So I think RAM is pretty"
     },
     {
       "speakerLabel": "spk_0",
       "start": 780.64,
       "end": 786.96,
-      "text": " powerful. It's probably a lot less complex than using resource policies or assume role for a lot"
+      "text": "powerful. It's probably a lot less complex than using resource policies or assume role for a lot"
     },
     {
       "speakerLabel": "spk_0",
       "start": 786.96,
       "end": 792.32,
-      "text": " of different services. And it avoids you having to duplicate resources and change identity as you"
+      "text": "of different services. And it avoids you having to duplicate resources and change identity as you"
     },
     {
       "speakerLabel": "spk_0",
       "start": 792.32,
       "end": 797.2,
-      "text": " have to with assume role. And I think that's all we have for today on Resource X as Manager."
+      "text": "have to with assume role. And I think that's all we have for today on Resource X as Manager."
     },
     {
       "speakerLabel": "spk_0",
       "start": 797.2,
       "end": 801.6,
-      "text": " Let us know what you think. If you have any other neat uses for it. Apart from that, don't forget"
+      "text": "Let us know what you think. If you have any other neat uses for it. Apart from that, don't forget"
     },
     {
       "speakerLabel": "spk_0",
       "start": 801.6,
       "end": 806.24,
-      "text": " to share the podcast or the YouTube channel with your friends and colleagues. So thanks very much"
+      "text": "to share the podcast or the YouTube channel with your friends and colleagues. So thanks very much"
     },
     {
       "speakerLabel": "spk_0",
       "start": 806.24,
       "end": 814.88,
-      "text": " for listening again, and we'll catch you in the next episode."
+      "text": "for listening again, and we'll catch you in the next episode."
     }
   ]
 }

--- a/src/_transcripts/116.json
+++ b/src/_transcripts/116.json
@@ -1,0 +1,878 @@
+{
+  "speakers": {
+    "spk_0": "spk_0",
+    "spk_1": "spk_1"
+  },
+  "segments": [
+    {
+      "speakerLabel": "spk_0",
+      "start": 0,
+      "end": 4.72,
+      "text": " Sharing is caring and if you are following the current best practices of using multiple AWS"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 4.72,
+      "end": 9.200000000000001,
+      "text": " accounts, you'll end up having to share resources between accounts. For some things, you might be"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 9.200000000000001,
+      "end": 14.64,
+      "text": " able to use resource-based policies to grant access or assume a role in the target account."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 14.64,
+      "end": 19.92,
+      "text": " This isn't suitable for everything, however, but luckily there is another way. Today, we are going"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 19.92,
+      "end": 24.96,
+      "text": " to chat about Resource Access Manager and by the end of the episode, you should know what it does"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 25.04,
+      "end": 30.16,
+      "text": " and how to use it. I'm Eoin, as always, I'm here with Luciano and this is AWS Bites."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 38.24,
+      "end": 43.68,
+      "text": " AWS Bites is brought to you by fourTheorem, the AWS partner who works with you to build successful"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 43.68,
+      "end": 49.92,
+      "text": " projects in the cloud. Check us out at fortherem.com. Luciano, maybe you can start and tell us all"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 50.480000000000004,
+      "end": 53.84,
+      "text": " what kind of problems is Resource Access Manager designed to solve?"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 53.84,
+      "end": 60.480000000000004,
+      "text": " Yes."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 60.480000000000004,
+      "end": 65.52000000000001,
+      "text": " So AWS Resource Access Manager or RAM, which is not to be confused with random access memory, by the way, it's the same acronym. So this is a tool that is designed to solve the problem of"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 65.52000000000001,
+      "end": 71.92,
+      "text": " securely sharing AWS resources across different AWS accounts within an organization or even with"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 71.92,
+      "end": 78.32000000000001,
+      "text": " external organizations. It is basically designed to do this while it tries to reduce the cost"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 78.32,
+      "end": 83.36,
+      "text": " by eliminating, for instance, resource duplications. You can simplify centralized"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 83.36,
+      "end": 88.32,
+      "text": " access to resources and it can achieve security and compliance. So RAM allows you to share"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 88.32,
+      "end": 94.88,
+      "text": " resources with, as I said, AWS accounts, including the ones outside or inside the organization."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 94.88,
+      "end": 99.11999999999999,
+      "text": " It can also share resources with accounts in a specific organization. So depending on the resource"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 99.11999999999999,
+      "end": 104.96,
+      "text": " type, you can share things with, for instance, the organization itself and organization units with"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 104.96,
+      "end": 110.47999999999999,
+      "text": " all the accounts inside of it or specific accounts. And you can also share resources with"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 110.47999999999999,
+      "end": 115.91999999999999,
+      "text": " identities like users, roles. The pricing is interesting because effectively there is no"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 115.91999999999999,
+      "end": 121.6,
+      "text": " additional costs. You only pay for the services that you are actually sharing. So you are creating"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 121.6,
+      "end": 127.36,
+      "text": " resources that you share and you're going to be paying for those resources. Now, what are some of"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 127.36,
+      "end": 133.68,
+      "text": " the use cases? The most common one you're likely to come across with RAM is VPC subnet sharing."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 133.68,
+      "end": 139.6,
+      "text": " Now, before Resource Access Manager, VPCs in different accounts, if you wanted to share them,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 139.6,
+      "end": 145.12,
+      "text": " it generally meant using something like VPC peering or transit gateway. If you share subnets"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 145.12,
+      "end": 152.24,
+      "text": " in a VPC with RAM accounts, then get access to implicit routing in that VPC. So if you have a"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 152.24,
+      "end": 157.44,
+      "text": " VPC in the owner account, you share it with participants and participating accounts, then"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 157.44,
+      "end": 163.36,
+      "text": " they can use that subnet and it allows them to implicitly route within other resources already"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 163.36,
+      "end": 168.8,
+      "text": " in that VPC. The IP address allocation then within the centrally managed subnets"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 168.8,
+      "end": 175.36,
+      "text": " can be managed by a network team. So that's one of the advantages of this shared services VPC model."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 175.36,
+      "end": 181.20000000000002,
+      "text": " Accounts with access to the shared resource then can access databases or VPC endpoints or other"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 181.20000000000002,
+      "end": 187.44000000000003,
+      "text": " servers running in the subnets. So how does it work? Well, if you've got this shared services"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 187.44000000000003,
+      "end": 193.04000000000002,
+      "text": " account, you create your VPCs and subnets in it, then you share the subnets with other accounts."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 193.36,
+      "end": 198.72000000000003,
+      "text": " Within an organization and participants can then see those shared subnets in their account."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 198.72000000000003,
+      "end": 205.04000000000002,
+      "text": " Now let's go back to the resource owner account. If they start an EC2 instance in the shared VPC,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 205.04000000000002,
+      "end": 209.36,
+      "text": " only they can see it. You're not sharing all of the things in the subnet per se."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 210.08,
+      "end": 215.28000000000003,
+      "text": " Participants can't make networking changes. So only the owner can make changes to the subnets,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 215.84,
+      "end": 221.52,
+      "text": " but participants can provision resources they own into shared subnets. Like they can start"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 221.52,
+      "end": 227.52,
+      "text": " their own EC2 instances in the account in the shared subnet. The participant will then own the"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 227.52,
+      "end": 234.88,
+      "text": " EC2 instance, even though the shared owner account owns the subnet. I suppose it's worth saying that"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 234.88,
+      "end": 239.44,
+      "text": " sharing subnets is very different solution to using VPC peering and Transit Gateway."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 239.44,
+      "end": 244.56,
+      "text": " And you might use them in combination actually, because sharing with RAM means that you have"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 244.56,
+      "end": 249.68,
+      "text": " access to an existing subnet. It doesn't really provide any additional routing. It just allows"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 249.68,
+      "end": 255.04000000000002,
+      "text": " you to launch resources into existing subnets. If you wanted to have routing into this shared"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 255.04000000000002,
+      "end": 261.36,
+      "text": " services VPC, you still need to do something like VPC peering or use Transit Gateway to route from"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 261.36,
+      "end": 267.36,
+      "text": " one VPC to another, just like you do between any two VPCs. So RAM is not a routing solution,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 268.4,
+      "end": 273.04,
+      "text": " and that's something to be aware of, but you can combine it with things like Transit Gateway and"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 273.04,
+      "end": 278.72,
+      "text": " peering. So that's the most common use case, I think, VPC sharing. Apart from networking,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 278.72,
+      "end": 283.44000000000005,
+      "text": " there are many other things you can share with RAM. AppSync APIs are one thing. There's code"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 283.44000000000005,
+      "end": 288.48,
+      "text": " build projects. You can share capacity reservations, which is interesting for"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 288.48,
+      "end": 295.12,
+      "text": " optimizing compute capacity costs. You can share FSX volumes. You can share GLUE catalogs, tables,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 295.12,
+      "end": 302.96000000000004,
+      "text": " and databases. So if you've got these catalogs in GLUE for access to data on S3, you can share it"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 302.96000000000004,
+      "end": 307.68,
+      "text": " this way rather than having to duplicate those resources in many accounts. If you have a private"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 307.68,
+      "end": 313.36,
+      "text": " certificate authority with the AWS Private CA, you can share that too. One of the things that"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 313.36,
+      "end": 319.04,
+      "text": " one of our colleagues, Connor, wrote an article about was using RAM to share Aurora databases."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 319.04,
+      "end": 322.72,
+      "text": " So he has a really good blog post on that. We're going to link that in the show notes."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 322.72,
+      "end": 329.52,
+      "text": " Another topic for where we wrote a blog was VPC lattice. And VPC lattice is a really cool topic."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 329.52,
+      "end": 333.92,
+      "text": " And if you haven't discovered it or haven't seen our previous episode, I'd recommend you check it"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 333.92,
+      "end": 340.40000000000003,
+      "text": " out because it leverages RAM highly to share services and service networks. We have the episode"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 340.40000000000003,
+      "end": 344.56,
+      "text": " on that. We have a blog post, and we have a sample application code. And the links for all three will"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 344.56,
+      "end": 350,
+      "text": " be in the show notes. Transit gateways themselves are things you can share with RAM. And hot off the"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 350,
+      "end": 356.32,
+      "text": " press, there is a new resource since last week only, I believe, which is sharing Systems Manager"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 356.32,
+      "end": 362.16,
+      "text": " Parameter Store parameters, otherwise known as SSM parameters. This is something which people have"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 362.16,
+      "end": 366.40000000000003,
+      "text": " been very excited about to hear because previously, you would really have to replicate those"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 366.40000000000003,
+      "end": 371.20000000000005,
+      "text": " parameters. And there wasn't any way to share them across account. Now, if you've got parameters,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 371.20000000000005,
+      "end": 378,
+      "text": " let's say for custom AMI for an EC2 instance, and you want to share that across multiple accounts,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 378,
+      "end": 383.52000000000004,
+      "text": " everybody can discover the latest version of the AMI. You can now do that with parameter store."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 383.52000000000004,
+      "end": 388.72,
+      "text": " There's a couple of gotchas to know with SSM parameter sharing. It only works for advanced"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 388.72,
+      "end": 393.6,
+      "text": " tier ones. So those are, I'm afraid, the more expensive ones, about $0.05 a month each."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 394.16,
+      "end": 399.04,
+      "text": " It doesn't work for the standard tier, which is the free option. So it definitely seems like AWS"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 399.04,
+      "end": 402.64000000000004,
+      "text": " slipped up in allowing that standard tier to be free. And they're just trying to push all"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 402.64000000000004,
+      "end": 406.8,
+      "text": " of the features into the advanced tier from now on as a correction measure."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 407.92,
+      "end": 411.12,
+      "text": " Yushiano, those are some of the use cases. There are other services you can share with"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 411.12,
+      "end": 415.12,
+      "text": " RAM. You can check out the full list in the link in the show notes. But let's say people"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 415.2,
+      "end": 419.44,
+      "text": " want to use it. How do you get started? Yes."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 419.44,
+      "end": 425.92,
+      "text": " So there are a few steps that you need to follow. So first of all, you need to create a resource share in Resource Access Manager."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 425.92,
+      "end": 432.32,
+      "text": " And by default, every account you share with, so you share something with an account, that account"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 432.32,
+      "end": 437.12,
+      "text": " receives an invitation. And to avoid this, you can also enable sharing with the entire AWS"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 437.12,
+      "end": 443.2,
+      "text": " organization in the AWS Management Console. Normally, owner accounts as full access control"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 443.84,
+      "end": 448.71999999999997,
+      "text": " and the shared principles have limited subset of permission. So again, it's still the idea that"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 448.71999999999997,
+      "end": 455.2,
+      "text": " you are not giving up ownership. You are just allowing another account to see those resources"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 455.2,
+      "end": 459.12,
+      "text": " and use them in different ways, depending on the type of resource. When you create a share,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 459.12,
+      "end": 463.76,
+      "text": " you need to specify a few different things. First of all, the resource type, for instance,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 463.76,
+      "end": 470.24,
+      "text": " is it a subnet? Is it a blue catalog? Is it an SSM parameter or something else? Then you see the"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 470.24,
+      "end": 475.92,
+      "text": " list of the resources of that type and you can pick the specific resources that you want to share"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 475.92,
+      "end": 482.32,
+      "text": " on that list. And then you need to define the permissions that the recipients will get on the"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 482.32,
+      "end": 487.76,
+      "text": " resources you have selected. And this will be either AWS Managed Permission or for some resources,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 487.76,
+      "end": 493.2,
+      "text": " you can even create your own custom managed permissions. Each resource type has different"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 493.2,
+      "end": 498.48,
+      "text": " options for sharing within RAM and the supported options vary depending on the resource type."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 498.48,
+      "end": 504.08000000000004,
+      "text": " Options can be things like whether you can share with an account outside the organization or you"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 504.08000000000004,
+      "end": 509.04,
+      "text": " are maybe limited only to the account inside the specific organization. Whether you can share with"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 509.04,
+      "end": 514.8000000000001,
+      "text": " IAM users and roles, whether you can share with AWS Service Principles or whether you can use"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 514.8000000000001,
+      "end": 520.4,
+      "text": " custom managed permissions. So again, there is a guided process if you use the AWS Console and as"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 520.4,
+      "end": 525.2,
+      "text": " you go through, you will see different screens and different options depending on the resources that"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 525.2,
+      "end": 530.72,
+      "text": " you have selected. We will link to the documentation for more details just to get a better overview of"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 530.72,
+      "end": 535.44,
+      "text": " what's possible, which resources can be shared and what options are available for every resource."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 535.44,
+      "end": 539.6800000000001,
+      "text": " But just to give you an example, if you want to share a subnet, all of the options that we"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 539.6800000000001,
+      "end": 544.48,
+      "text": " mentioned are not available for this particular resource. What you cannot do, for instance, you"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 544.48,
+      "end": 549.76,
+      "text": " cannot share with accounts outside the organization. So if you're sharing a subnet, that's going to be"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 549.76,
+      "end": 554.24,
+      "text": " available only for the accounts inside your organization. You cannot share a subnet with"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 554.24,
+      "end": 560,
+      "text": " specific IAM users and roles, and you cannot share it with Service Principles. And you have to use"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 560,
+      "end": 567.2,
+      "text": " default AWS Managed Permissions. So effectively, you can allow participants to launch instances"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 567.2,
+      "end": 573.12,
+      "text": " within the subnet, create EAPs and things like that that are predefined in AWS. You cannot really"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 573.12,
+      "end": 580.72,
+      "text": " just create your own set of permissions and decide in a fine-grained way what people can do with that subnet."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 580.72,
+      "end": 585.6800000000001,
+      "text": " I guess you could, if you wanted to restrict that, use a Service Control Policy. One of the things we"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 585.6800000000001,
+      "end": 589.84,
+      "text": " talked about recently, if you wanted to narrow down those permissions, but I don't know what"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 589.84,
+      "end": 594.8000000000001,
+      "text": " your reason for that might be, maybe people can give some suggestions."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 594.8000000000001,
+      "end": 601.6,
+      "text": " Yeah, that's a really good point. But I guess the next question would be, once you share something from the ownership side,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 601.6,
+      "end": 606.8000000000001,
+      "text": " so you are sharing from a specific account, what would that look like from the participant side?"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 606.8,
+      "end": 612.4,
+      "text": " So whoever is receiving access to that particular resource or set of resources."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 612.4,
+      "end": 617.92,
+      "text": " Yeah, so from the participant side, then if you go into RAM, you'll get a complete overview of all the shares and the"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 617.92,
+      "end": 622.64,
+      "text": " resources shared within your account. So you can see what people have shared with you. And then"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 622.64,
+      "end": 629.04,
+      "text": " when you go to see specific resources, like if you go into the VPC console, select a subnet, you will"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 629.04,
+      "end": 633.4399999999999,
+      "text": " see the owner account column in the table. And you can see that the owner account is a different"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 633.44,
+      "end": 639.2800000000001,
+      "text": " identifier than your account. And that's how you know it's an externally managed resource. If you"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 639.2800000000001,
+      "end": 645.12,
+      "text": " share subnets, you can also see the associated VPC in the VPC console, which is maybe a little"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 645.12,
+      "end": 651.0400000000001,
+      "text": " bit unexpected, because you haven't explicitly shared the VPC itself. The VPC as a thing is not"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 651.0400000000001,
+      "end": 658.4000000000001,
+      "text": " a shareable resource with RAM. And participants can tag resources with separate tags to the shared"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 658.4,
+      "end": 663.1999999999999,
+      "text": " resource, which is also probably unexpected, because you might expect that tags are an"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 663.1999999999999,
+      "end": 668.72,
+      "text": " implicit part of the resource. But tags are almost like a separate resource that's linked to the"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 668.72,
+      "end": 675.28,
+      "text": " subnet itself. So when you share a subnet, you don't share the tags, you can give us new tags in"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 675.28,
+      "end": 681.1999999999999,
+      "text": " the participant account. Another unexpected thing you might see when you start sharing subnets"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 681.2,
+      "end": 689.84,
+      "text": " across accounts is that you might share a subnet in US East 1A, right, availability zone. And when"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 689.84,
+      "end": 695.44,
+      "text": " you look at it in the participant account, you might see that it's called US East 1B. And you"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 695.44,
+      "end": 700.24,
+      "text": " will wonder what that's all about, and how they seem to have moved from a different data center"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 700.24,
+      "end": 705.2,
+      "text": " to 130 miles away. And the reason for that, you may know, but in case you don't, it's worth"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 705.2,
+      "end": 712.32,
+      "text": " stating it. When you create a new AWS account, AWS randomly assigns these availability zone labels"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 712.88,
+      "end": 720,
+      "text": " to you in a just in a randomized way. So everybody's US East 1A may be different. And if you"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 720,
+      "end": 725.9200000000001,
+      "text": " want to see if they're actually in the same AZ, there's another identifier called the AZ ID. And"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 725.9200000000001,
+      "end": 734.5600000000001,
+      "text": " this has a format like EUW1-AZ2. And these are physical AZ identifiers, and they do not change"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 734.56,
+      "end": 739.28,
+      "text": " per account. So the whole idea with randomizing them is they don't want everybody to just pick"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 739.28,
+      "end": 744.0799999999999,
+      "text": " the first AZ when they're launching something, and then have unbalanced load across their"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 744.0799999999999,
+      "end": 750.2399999999999,
+      "text": " availability zones. So that's why to randomize them. If you are using availability zones names,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 750.2399999999999,
+      "end": 754.64,
+      "text": " then remember, they don't necessarily line up from account to account. I think one thing you"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 754.64,
+      "end": 759.8399999999999,
+      "text": " mentioned as well Luciano, which is worth highlighting again, is that sharing within an"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 759.84,
+      "end": 764.32,
+      "text": " organization, if you want to make it easier, in fact, for some resources, you have to do this"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 764.32,
+      "end": 770.24,
+      "text": " anyway. So it's probably worthwhile doing it, you just go into RAM in the management account,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 770.24,
+      "end": 775.2,
+      "text": " and enable sharing inside the organization. And then when you share resources, the acceptance is"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 775.2,
+      "end": 780.64,
+      "text": " automatic, the participating accounts don't have to accept an invitation. So I think RAM is pretty"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 780.64,
+      "end": 786.96,
+      "text": " powerful. It's probably a lot less complex than using resource policies or assume role for a lot"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 786.96,
+      "end": 792.32,
+      "text": " of different services. And it avoids you having to duplicate resources and change identity as you"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 792.32,
+      "end": 797.2,
+      "text": " have to with assume role. And I think that's all we have for today on Resource X as Manager."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 797.2,
+      "end": 801.6,
+      "text": " Let us know what you think. If you have any other neat uses for it. Apart from that, don't forget"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 801.6,
+      "end": 806.24,
+      "text": " to share the podcast or the YouTube channel with your friends and colleagues. So thanks very much"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 806.24,
+      "end": 814.88,
+      "text": " for listening again, and we'll catch you in the next episode."
+    }
+  ]
+}

--- a/src/_transcripts/116.vtt
+++ b/src/_transcripts/116.vtt
@@ -1,0 +1,581 @@
+WEBVTT
+
+1
+00:00:00.000 --> 00:00:04.720
+Sharing is caring and if you are following the current best practices of using multiple AWS
+
+2
+00:00:04.720 --> 00:00:09.200
+accounts, you'll end up having to share resources between accounts. For some things, you might be
+
+3
+00:00:09.200 --> 00:00:14.640
+able to use resource-based policies to grant access or assume a role in the target account.
+
+4
+00:00:14.640 --> 00:00:19.920
+This isn't suitable for everything, however, but luckily there is another way. Today, we are going
+
+5
+00:00:19.920 --> 00:00:24.960
+to chat about Resource Access Manager and by the end of the episode, you should know what it does
+
+6
+00:00:25.040 --> 00:00:30.160
+and how to use it. I'm Eoin, as always, I'm here with Luciano and this is AWS Bites.
+
+7
+00:00:38.240 --> 00:00:43.680
+AWS Bites is brought to you by fourTheorem, the AWS partner who works with you to build successful
+
+8
+00:00:43.680 --> 00:00:49.920
+projects in the cloud. Check us out at fourtherem.com. Luciano, maybe you can start and tell us all
+
+9
+00:00:50.480 --> 00:00:53.840
+what kind of problems is Resource Access Manager designed to solve?
+
+10
+00:00:53.840 --> 00:01:00.480
+Yes.
+
+11
+00:01:00.480 --> 00:01:05.520
+So AWS Resource Access Manager or RAM, which is not to be confused with random access memory, by the way, it's the same acronym. So this is a tool that is designed to solve the problem of
+
+12
+00:01:05.520 --> 00:01:11.920
+securely sharing AWS resources across different AWS accounts within an organization or even with
+
+13
+00:01:11.920 --> 00:01:18.320
+external organizations. It is basically designed to do this while it tries to reduce the cost
+
+14
+00:01:18.320 --> 00:01:23.360
+by eliminating, for instance, resource duplications. You can simplify centralized
+
+15
+00:01:23.360 --> 00:01:28.320
+access to resources and it can achieve security and compliance. So RAM allows you to share
+
+16
+00:01:28.320 --> 00:01:34.880
+resources with, as I said, AWS accounts, including the ones outside or inside the organization.
+
+17
+00:01:34.880 --> 00:01:39.120
+It can also share resources with accounts in a specific organization. So depending on the resource
+
+18
+00:01:39.120 --> 00:01:44.960
+type, you can share things with, for instance, the organization itself and organization units with
+
+19
+00:01:44.960 --> 00:01:50.480
+all the accounts inside of it or specific accounts. And you can also share resources with
+
+20
+00:01:50.480 --> 00:01:55.920
+identities like users, roles. The pricing is interesting because effectively there is no
+
+21
+00:01:55.920 --> 00:02:01.600
+additional costs. You only pay for the services that you are actually sharing. So you are creating
+
+22
+00:02:01.600 --> 00:02:07.360
+resources that you share and you're going to be paying for those resources. Now, what are some of
+
+23
+00:02:07.360 --> 00:02:13.680
+the use cases? The most common one you're likely to come across with RAM is VPC subnet sharing.
+
+24
+00:02:13.680 --> 00:02:19.600
+Now, before Resource Access Manager, VPCs in different accounts, if you wanted to share them,
+
+25
+00:02:19.600 --> 00:02:25.120
+it generally meant using something like VPC peering or transit gateway. If you share subnets
+
+26
+00:02:25.120 --> 00:02:32.240
+in a VPC with RAM accounts, then get access to implicit routing in that VPC. So if you have a
+
+27
+00:02:32.240 --> 00:02:37.440
+VPC in the owner account, you share it with participants and participating accounts, then
+
+28
+00:02:37.440 --> 00:02:43.360
+they can use that subnet and it allows them to implicitly route within other resources already
+
+29
+00:02:43.360 --> 00:02:48.800
+in that VPC. The IP address allocation then within the centrally managed subnets
+
+30
+00:02:48.800 --> 00:02:55.360
+can be managed by a network team. So that's one of the advantages of this shared services VPC model.
+
+31
+00:02:55.360 --> 00:03:01.200
+Accounts with access to the shared resource then can access databases or VPC endpoints or other
+
+32
+00:03:01.200 --> 00:03:07.440
+servers running in the subnets. So how does it work? Well, if you've got this shared services
+
+33
+00:03:07.440 --> 00:03:13.040
+account, you create your VPCs and subnets in it, then you share the subnets with other accounts.
+
+34
+00:03:13.360 --> 00:03:18.720
+Within an organization and participants can then see those shared subnets in their account.
+
+35
+00:03:18.720 --> 00:03:25.040
+Now let's go back to the resource owner account. If they start an EC2 instance in the shared VPC,
+
+36
+00:03:25.040 --> 00:03:29.360
+only they can see it. You're not sharing all of the things in the subnet per se.
+
+37
+00:03:30.080 --> 00:03:35.280
+Participants can't make networking changes. So only the owner can make changes to the subnets,
+
+38
+00:03:35.840 --> 00:03:41.520
+but participants can provision resources they own into shared subnets. Like they can start
+
+39
+00:03:41.520 --> 00:03:47.520
+their own EC2 instances in the account in the shared subnet. The participant will then own the
+
+40
+00:03:47.520 --> 00:03:54.880
+EC2 instance, even though the shared owner account owns the subnet. I suppose it's worth saying that
+
+41
+00:03:54.880 --> 00:03:59.440
+sharing subnets is very different solution to using VPC peering and Transit Gateway.
+
+42
+00:03:59.440 --> 00:04:04.560
+And you might use them in combination actually, because sharing with RAM means that you have
+
+43
+00:04:04.560 --> 00:04:09.680
+access to an existing subnet. It doesn't really provide any additional routing. It just allows
+
+44
+00:04:09.680 --> 00:04:15.040
+you to launch resources into existing subnets. If you wanted to have routing into this shared
+
+45
+00:04:15.040 --> 00:04:21.360
+services VPC, you still need to do something like VPC peering or use Transit Gateway to route from
+
+46
+00:04:21.360 --> 00:04:27.360
+one VPC to another, just like you do between any two VPCs. So RAM is not a routing solution,
+
+47
+00:04:28.400 --> 00:04:33.040
+and that's something to be aware of, but you can combine it with things like Transit Gateway and
+
+48
+00:04:33.040 --> 00:04:38.720
+peering. So that's the most common use case, I think, VPC sharing. Apart from networking,
+
+49
+00:04:38.720 --> 00:04:43.440
+there are many other things you can share with RAM. AppSync APIs are one thing. There's code
+
+50
+00:04:43.440 --> 00:04:48.480
+build projects. You can share capacity reservations, which is interesting for
+
+51
+00:04:48.480 --> 00:04:55.120
+optimizing compute capacity costs. You can share FSX volumes. You can share GLUE catalogs, tables,
+
+52
+00:04:55.120 --> 00:05:02.960
+and databases. So if you've got these catalogs in GLUE for access to data on S3, you can share it
+
+53
+00:05:02.960 --> 00:05:07.680
+this way rather than having to duplicate those resources in many accounts. If you have a private
+
+54
+00:05:07.680 --> 00:05:13.360
+certificate authority with the AWS Private CA, you can share that too. One of the things that
+
+55
+00:05:13.360 --> 00:05:19.040
+one of our colleagues, Connor, wrote an article about was using RAM to share Aurora databases.
+
+56
+00:05:19.040 --> 00:05:22.720
+So he has a really good blog post on that. We're going to link that in the show notes.
+
+57
+00:05:22.720 --> 00:05:29.520
+Another topic for where we wrote a blog was VPC lattice. And VPC lattice is a really cool topic.
+
+58
+00:05:29.520 --> 00:05:33.920
+And if you haven't discovered it or haven't seen our previous episode, I'd recommend you check it
+
+59
+00:05:33.920 --> 00:05:40.400
+out because it leverages RAM highly to share services and service networks. We have the episode
+
+60
+00:05:40.400 --> 00:05:44.560
+on that. We have a blog post, and we have a sample application code. And the links for all three will
+
+61
+00:05:44.560 --> 00:05:50.000
+be in the show notes. Transit gateways themselves are things you can share with RAM. And hot off the
+
+62
+00:05:50.000 --> 00:05:56.320
+press, there is a new resource since last week only, I believe, which is sharing Systems Manager
+
+63
+00:05:56.320 --> 00:06:02.160
+Parameter Store parameters, otherwise known as SSM parameters. This is something which people have
+
+64
+00:06:02.160 --> 00:06:06.400
+been very excited about to hear because previously, you would really have to replicate those
+
+65
+00:06:06.400 --> 00:06:11.200
+parameters. And there wasn't any way to share them across account. Now, if you've got parameters,
+
+66
+00:06:11.200 --> 00:06:18.000
+let's say for custom AMI for an EC2 instance, and you want to share that across multiple accounts,
+
+67
+00:06:18.000 --> 00:06:23.520
+everybody can discover the latest version of the AMI. You can now do that with parameter store.
+
+68
+00:06:23.520 --> 00:06:28.720
+There's a couple of gotchas to know with SSM parameter sharing. It only works for advanced
+
+69
+00:06:28.720 --> 00:06:33.600
+tier ones. So those are, I'm afraid, the more expensive ones, about $0.05 a month each.
+
+70
+00:06:34.160 --> 00:06:39.040
+It doesn't work for the standard tier, which is the free option. So it definitely seems like AWS
+
+71
+00:06:39.040 --> 00:06:42.640
+slipped up in allowing that standard tier to be free. And they're just trying to push all
+
+72
+00:06:42.640 --> 00:06:46.800
+of the features into the advanced tier from now on as a correction measure.
+
+73
+00:06:47.920 --> 00:06:51.120
+Luciano, those are some of the use cases. There are other services you can share with
+
+74
+00:06:51.120 --> 00:06:55.120
+RAM. You can check out the full list in the link in the show notes. But let's say people
+
+75
+00:06:55.200 --> 00:06:59.440
+want to use it. How do you get started?
+
+76
+00:06:59.440 --> 00:07:05.920
+Yes. So there are a few steps that you need to follow. So first of all, you need to create a resource share in Resource Access Manager.
+
+77
+00:07:05.920 --> 00:07:12.320
+And by default, every account you share with, so you share something with an account, that account
+
+78
+00:07:12.320 --> 00:07:17.120
+receives an invitation. And to avoid this, you can also enable sharing with the entire AWS
+
+79
+00:07:17.120 --> 00:07:23.200
+organization in the AWS Management Console. Normally, owner accounts have full access control
+
+80
+00:07:23.840 --> 00:07:28.720
+and the shared principles have limited subset of permission. So again, it's still the idea that
+
+81
+00:07:28.720 --> 00:07:35.200
+you are not giving up ownership. You are just allowing another account to see those resources
+
+82
+00:07:35.200 --> 00:07:39.120
+and use them in different ways, depending on the type of resource. When you create a share,
+
+83
+00:07:39.120 --> 00:07:43.760
+you need to specify a few different things. First of all, the resource type, for instance,
+
+84
+00:07:43.760 --> 00:07:50.240
+is it a subnet? Is it a blue catalog? Is it an SSM parameter or something else? Then you see the
+
+85
+00:07:50.240 --> 00:07:55.920
+list of the resources of that type and you can pick the specific resources that you want to share
+
+86
+00:07:55.920 --> 00:08:02.320
+on that list. And then you need to define the permissions that the recipients will get on the
+
+87
+00:08:02.320 --> 00:08:07.760
+resources you have selected. And this will be either AWS Managed Permission or for some resources,
+
+88
+00:08:07.760 --> 00:08:13.200
+you can even create your own custom managed permissions. Each resource type has different
+
+89
+00:08:13.200 --> 00:08:18.480
+options for sharing within RAM and the supported options vary depending on the resource type.
+
+90
+00:08:18.480 --> 00:08:24.080
+Options can be things like whether you can share with an account outside the organization or you
+
+91
+00:08:24.080 --> 00:08:29.040
+are maybe limited only to the account inside the specific organization. Whether you can share with
+
+92
+00:08:29.040 --> 00:08:34.800
+IAM users and roles, whether you can share with AWS Service Principles or whether you can use
+
+93
+00:08:34.800 --> 00:08:40.400
+custom managed permissions. So again, there is a guided process if you use the AWS Console and as
+
+94
+00:08:40.400 --> 00:08:45.200
+you go through, you will see different screens and different options depending on the resources that
+
+95
+00:08:45.200 --> 00:08:50.720
+you have selected. We will link to the documentation for more details just to get a better overview of
+
+96
+00:08:50.720 --> 00:08:55.440
+what's possible, which resources can be shared and what options are available for every resource.
+
+97
+00:08:55.440 --> 00:08:59.680
+But just to give you an example, if you want to share a subnet, all of the options that we
+
+98
+00:08:59.680 --> 00:09:04.480
+mentioned are not available for this particular resource. What you cannot do, for instance, you
+
+99
+00:09:04.480 --> 00:09:09.760
+cannot share with accounts outside the organization. So if you're sharing a subnet, that's going to be
+
+100
+00:09:09.760 --> 00:09:14.240
+available only for the accounts inside your organization. You cannot share a subnet with
+
+101
+00:09:14.240 --> 00:09:20.000
+specific IAM users and roles, and you cannot share it with Service Principles. And you have to use
+
+102
+00:09:20.000 --> 00:09:27.200
+default AWS Managed Permissions. So effectively, you can allow participants to launch instances
+
+103
+00:09:27.200 --> 00:09:33.120
+within the subnet, create EIPs and things like that that are predefined in AWS. You cannot really
+
+104
+00:09:33.120 --> 00:09:40.720
+just create your own set of permissions and decide in a fine-grained way what people can do with that subnet.
+
+105
+00:09:40.720 --> 00:09:45.680
+I guess you could, if you wanted to restrict that, use a Service Control Policy. One of the things we
+
+106
+00:09:45.680 --> 00:09:49.840
+talked about recently, if you wanted to narrow down those permissions, but I don't know what
+
+107
+00:09:49.840 --> 00:09:54.800
+your reason for that might be, maybe people can give some suggestions.
+
+108
+00:09:54.800 --> 00:10:01.600
+Yeah, that's a really good point. But I guess the next question would be, once you share something from the ownership side,
+
+109
+00:10:01.600 --> 00:10:06.800
+so you are sharing from a specific account, what would that look like from the participant side?
+
+110
+00:10:06.800 --> 00:10:12.400
+So whoever is receiving access to that particular resource or set of resources.
+
+111
+00:10:12.400 --> 00:10:17.920
+Yeah, so from the participant side, then if you go into RAM, you'll get a complete overview of all the shares and the
+
+112
+00:10:17.920 --> 00:10:22.640
+resources shared within your account. So you can see what people have shared with you. And then
+
+113
+00:10:22.640 --> 00:10:29.040
+when you go to see specific resources, like if you go into the VPC console, select a subnet, you will
+
+114
+00:10:29.040 --> 00:10:33.440
+see the owner account column in the table. And you can see that the owner account is a different
+
+115
+00:10:33.440 --> 00:10:39.280
+identifier than your account. And that's how you know it's an externally managed resource. If you
+
+116
+00:10:39.280 --> 00:10:45.120
+share subnets, you can also see the associated VPC in the VPC console, which is maybe a little
+
+117
+00:10:45.120 --> 00:10:51.040
+bit unexpected, because you haven't explicitly shared the VPC itself. The VPC as a thing is not
+
+118
+00:10:51.040 --> 00:10:58.400
+a shareable resource with RAM. And participants can tag resources with separate tags to the shared
+
+119
+00:10:58.400 --> 00:11:03.200
+resource, which is also probably unexpected, because you might expect that tags are an
+
+120
+00:11:03.200 --> 00:11:08.720
+implicit part of the resource. But tags are almost like a separate resource that's linked to the
+
+121
+00:11:08.720 --> 00:11:15.280
+subnet itself. So when you share a subnet, you don't share the tags, you can give us new tags in
+
+122
+00:11:15.280 --> 00:11:21.200
+the participant account. Another unexpected thing you might see when you start sharing subnets
+
+123
+00:11:21.200 --> 00:11:29.840
+across accounts is that you might share a subnet in us-east-1a, right, availability zone. And when
+
+124
+00:11:29.840 --> 00:11:35.440
+you look at it in the participant account, you might see that it's called us-east-1b. And you
+
+125
+00:11:35.440 --> 00:11:40.240
+will wonder what that's all about, and how they seem to have moved from a different data center
+
+126
+00:11:40.240 --> 00:11:45.200
+to one 30 miles away. And the reason for that, you may know, but in case you don't, it's worth
+
+127
+00:11:45.200 --> 00:11:52.320
+stating it. When you create a new AWS account, AWS randomly assigns these availability zone labels
+
+128
+00:11:52.880 --> 00:12:00.000
+to you in a just in a randomized way. So everybody's US East 1A may be different. And if you
+
+129
+00:12:00.000 --> 00:12:05.920
+want to see if they're actually in the same AZ, there's another identifier called the AZ ID. And
+
+130
+00:12:05.920 --> 00:12:14.560
+this has a format like EUW1-AZ2. And these are physical AZ identifiers, and they do not change
+
+131
+00:12:14.560 --> 00:12:19.280
+per account. So the whole idea with randomizing them is they don't want everybody to just pick
+
+132
+00:12:19.280 --> 00:12:24.080
+the first AZ when they're launching something, and then have unbalanced load across their
+
+133
+00:12:24.080 --> 00:12:30.240
+availability zones. So that's why to randomize them. If you are using availability zones names,
+
+134
+00:12:30.240 --> 00:12:34.640
+then remember, they don't necessarily line up from account to account. I think one thing you
+
+135
+00:12:34.640 --> 00:12:39.840
+mentioned as well Luciano, which is worth highlighting again, is that sharing within an
+
+136
+00:12:39.840 --> 00:12:44.320
+organization, if you want to make it easier, in fact, for some resources, you have to do this
+
+137
+00:12:44.320 --> 00:12:50.240
+anyway. So it's probably worthwhile doing it, you just go into RAM in the management account,
+
+138
+00:12:50.240 --> 00:12:55.200
+and enable sharing inside the organization. And then when you share resources, the acceptance is
+
+139
+00:12:55.200 --> 00:13:00.640
+automatic, the participating accounts don't have to accept an invitation. So I think RAM is pretty
+
+140
+00:13:00.640 --> 00:13:06.960
+powerful. It's probably a lot less complex than using resource policies or assume role for a lot
+
+141
+00:13:06.960 --> 00:13:12.320
+of different services. And it avoids you having to duplicate resources and change identity as you
+
+142
+00:13:12.320 --> 00:13:17.200
+have to with assume role. And I think that's all we have for today on Resource X as Manager.
+
+143
+00:13:17.200 --> 00:13:21.600
+Let us know what you think. If you have any other neat uses for it. Apart from that, don't forget
+
+144
+00:13:21.600 --> 00:13:26.240
+to share the podcast or the YouTube channel with your friends and colleagues. So thanks very much
+
+145
+00:13:26.240 --> 00:13:34.880
+for listening again, and we'll catch you in the next episode.


### PR DESCRIPTION

# Transcript

This change includes the transcript for the podcast episode, created by [Podwhisperer](https://github.com/fourTheorem/podwhisperer).
The summary below is generated by [Episoder](https://github.com/fourTheorem/episoder).

## Episode Summary

In this episode, we discuss AWS Resource Access Manager (RAM) and how it can be used to securely share AWS resources like VPC subnets, databases, and SSM parameters across accounts. We explain the benefits of using RAM over other options like resource policies and assumed roles. Some key topics covered include how to get started with RAM, how it works from the resource owner and resource participant side, and common use cases like sharing VPC subnets, Aurora databases, and SSM parameters.

## Suggested Chapters
00:00 Introduction to AWS Resource Access Manager and the problems it solves.
01:00 Overview of sharing resources with RAM across accounts and organizations.
02:13 Using RAM for sharing VPC subnets and the benefits over VPC peering.
09:40 How RAM works from the resource owner side when creating shares.
09:54 How RAM works from the resource participant side when accessing shared resources.

## Suggested Tags
AWS, RAM, Resource Access Manager, VPC, Subnets, Sharing, Organization, Accounts, Databases, Aurora, SSM, Parameters, Security, Compliance, Networking
