### PR TITLE
add episode 125 transcript

### DIFF
--- a/src/_transcripts/125.json
+++ b/src/_transcripts/125.json
@@ -1,7 +1,7 @@
 {
   "speakers": {
-    "spk_0": "spk_0",
-    "spk_1": "spk_1"
+    "spk_0": "Luciano",
+    "spk_1": "Eoin"
   },
   "segments": [
     {
@@ -14,7 +14,7 @@
       "speakerLabel": "spk_0",
       "start": 3.12,
       "end": 7.44,
-      "text": " CloudFront Austin Toolkit, a new tool that promises to streamline the experience"
+      "text": " CloudFront Hosting Toolkit, a new tool that promises to streamline the experience"
     },
     {
       "speakerLabel": "spk_0",
@@ -38,7 +38,7 @@
       "speakerLabel": "spk_0",
       "start": 20.32,
       "end": 24.560000000000002,
-      "text": " We took CloudFront Austin Toolkit for a spin and we are eager to tell you what we found out."
+      "text": " We took CloudFront Hosting Toolkit for a spin and we are eager to tell you what we found out."
     },
     {
       "speakerLabel": "spk_0",
@@ -68,7 +68,7 @@
       "speakerLabel": "spk_0",
       "start": 39.92,
       "end": 45.6,
-      "text": " We will then discuss CloudFront Austin Toolkit and see how it stands against this way of seeing modern front-ends."
+      "text": " We will then discuss CloudFront Hosting Toolkit and see how it stands against this way of seeing modern front-ends."
     },
     {
       "speakerLabel": "spk_0",
@@ -1343,12 +1343,6 @@
       "text": " hosting toolkit, and you've had some successes and some bumps in the road Luciano."
     },
     {
-      "speakerLabel": "spk_1",
-      "start": 1052.16,
-      "end": 1054.8,
-      "text": " Luciano Yes."
-    },
-    {
       "speakerLabel": "spk_0",
       "start": 1054.8,
       "end": 1061.52,
@@ -2141,7 +2135,7 @@
       "text": " sees the love and attention that we need. What's your take?"
     },
     {
-      "speakerLabel": "spk_1",
+      "speakerLabel": "spk_0",
       "start": 1694.48,
       "end": 1698.8000000000002,
       "text": " Yeah, I absolutely agree with everything you said."

--- a/src/_transcripts/125.json
+++ b/src/_transcripts/125.json
@@ -1,0 +1,2528 @@
+{
+  "speakers": {
+    "spk_0": "spk_0",
+    "spk_1": "spk_1"
+  },
+  "segments": [
+    {
+      "speakerLabel": "spk_0",
+      "start": 0,
+      "end": 3.12,
+      "text": " A couple of weeks ago, AWS announced a new open source tool,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 3.12,
+      "end": 7.44,
+      "text": " CloudFront Austin Toolkit, a new tool that promises to streamline the experience"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 7.44,
+      "end": 12.96,
+      "text": " of deploying front-end applications to AWS while retaining full control of the underlying infrastructure."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 12.96,
+      "end": 17.44,
+      "text": " We are particularly excited about this announcement because it was recognized by some people in the community"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 17.44,
+      "end": 20.32,
+      "text": " as the AWS response to something like Vercel."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 20.32,
+      "end": 24.560000000000002,
+      "text": " We took CloudFront Austin Toolkit for a spin and we are eager to tell you what we found out."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 24.560000000000002,
+      "end": 28.16,
+      "text": " In this episode, we'll discuss all about CloudFront and Toolkit,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 28.16,
+      "end": 33.36,
+      "text": " but we will also talk about modern front-ends and what's the expectation for a modern web application these days,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 33.36,
+      "end": 36.64,
+      "text": " brought from a user perspective, so visiting an application,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 36.64,
+      "end": 39.92,
+      "text": " but also from a developer perspective, so building that kind of application."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 39.92,
+      "end": 45.6,
+      "text": " We will then discuss CloudFront Austin Toolkit and see how it stands against this way of seeing modern front-ends."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 45.6,
+      "end": 50.400000000000006,
+      "text": " My name is Luciano and as always, I'm joined by Eoin for another episode of AWS Bites podcast."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 58.4,
+      "end": 64,
+      "text": " AWS Bites is brought to you by fourTheorem, an AWS consulting partner with tons of experience with AWS."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 64,
+      "end": 68.96,
+      "text": " If you need someone to help you with your ambitious AWS projects, check out fourTheorem.com."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 68.96,
+      "end": 72.16,
+      "text": " You can contact us directly using the links in the show notes."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 72.16,
+      "end": 77.36,
+      "text": " So maybe we can start this episode by describing what a modern front-end application looks like"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 77.36,
+      "end": 82.08,
+      "text": " because for many years, the golden standard of front-end application has been single page applications."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 82.08,
+      "end": 86.32,
+      "text": " And if you're not familiar with that definition, a single page application is effectively,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 86.32,
+      "end": 91.91999999999999,
+      "text": " you can imagine like a single HTML shell that is loaded and that shell only loads some JavaScript."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 91.91999999999999,
+      "end": 95.75999999999999,
+      "text": " And inside that JavaScript, you have all the logic that your application needs."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 95.75999999999999,
+      "end": 101.36,
+      "text": " So that JavaScript will do client-side routing, which basically means that once the application is loaded,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 101.36,
+      "end": 107.19999999999999,
+      "text": " there is JavaScript logic that will look at the current URL and decide which components need to be mounted"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 107.19999999999999,
+      "end": 110.47999999999999,
+      "text": " or unmounted to effectively refresh the page dynamically."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 110.47999999999999,
+      "end": 116.24,
+      "text": " It will also do client-side HTTP requests, something that has been called originally Ajax requests."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 116.24,
+      "end": 118.88,
+      "text": " In the past, now it's more called fetch requests."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 118.88,
+      "end": 123.11999999999999,
+      "text": " But the idea is that once the application is loaded, it doesn't really have any dynamic data,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 123.11999999999999,
+      "end": 125.28,
+      "text": " something that you might keep, for instance, in a database."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 125.28,
+      "end": 130.24,
+      "text": " So whenever you need to load dynamic data, you need to do HTTP requests to a backend API,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 130.24,
+      "end": 134.16,
+      "text": " and that API will give you the dynamic data that then can be displayed in the page."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 134.16,
+      "end": 138.32,
+      "text": " So this basically means that you can also the entire front-end as a static website"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 138.32,
+      "end": 140.95999999999998,
+      "text": " in something like CloudFront, for instance."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 140.95999999999998,
+      "end": 144.24,
+      "text": " And the great part of all of this is that you don't need a backend at all."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 144.24,
+      "end": 149.12,
+      "text": " It's just static files. The browser can load them, and all the business logic needed for your front-end"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 149.12,
+      "end": 151.84,
+      "text": " exists in those JavaScript files loaded by the browser."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 151.84,
+      "end": 155.60000000000002,
+      "text": " And this keeps things very simple, and it can be also very cost efficient,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 155.60000000000002,
+      "end": 160.4,
+      "text": " because once you host in S3 and CloudFront, that can scale to a massive amount,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 160.4,
+      "end": 162,
+      "text": " still with very little cost."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 162,
+      "end": 166.56,
+      "text": " The main frameworks that emerged in the last decade that try to cover this kind of use cases"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 166.56,
+      "end": 168.56,
+      "text": " are probably React, Vue, and Angular."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 168.56,
+      "end": 171.52,
+      "text": " There are so many others, and your framework comes out every week."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 171.52,
+      "end": 175.28,
+      "text": " But these are probably the three main ones that you will find in most projects."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 175.28,
+      "end": 179.12,
+      "text": " Now, there are some problems with this approach, this SPA's approach."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 179.12,
+      "end": 183.60000000000002,
+      "text": " One problem is that you have perceived loading times that can be very long."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 183.60000000000002,
+      "end": 187.92000000000002,
+      "text": " And this is because until all the JavaScript is loaded in the page, you basically see an empty page."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 187.92000000000002,
+      "end": 192.64000000000001,
+      "text": " You see just a white screen, and it might look like the website is broken if it takes too long."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 192.64000000000001,
+      "end": 197.04000000000002,
+      "text": " And with some framework, it's actually very easy to forget to do some optimization,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 197.04000000000002,
+      "end": 200.88,
+      "text": " and you might end up with your JavaScript bundle that can be multiple megabytes."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 200.88,
+      "end": 205.35999999999999,
+      "text": " So really, lots of people might have this risk if they underestimate the effort and"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 205.35999999999999,
+      "end": 208.24,
+      "text": " optimize the JavaScript code that you just deploy your application,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 208.24,
+      "end": 212.24,
+      "text": " you expect everything works perfectly, but then the user has a very bad experience."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 212.24,
+      "end": 215.76,
+      "text": " We also mentioned that all dynamic data needs to be loaded externally."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 215.76,
+      "end": 218.96,
+      "text": " So that means that for all the kind of stuff, you need to build your own API,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 218.96,
+      "end": 224.32,
+      "text": " you need to deploy that API independently, and then your UI still needs to fetch all of that"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 224.32,
+      "end": 228.4,
+      "text": " data, which might add to the delay before the user can see something useful."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 228.4,
+      "end": 233.36,
+      "text": " And that also creates some SEO problems because search engines will access your website,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 233.36,
+      "end": 238.32,
+      "text": " but then everything is happening after JavaScript is loaded, and not every search engine will"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 238.32,
+      "end": 242.48000000000002,
+      "text": " actually wait for that amount of time or even try to run JavaScript."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 242.48000000000002,
+      "end": 248.88,
+      "text": " So your indexing against search engines might be not necessarily the best because it's going to be"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 248.88,
+      "end": 252.64000000000001,
+      "text": " very unpredictable what different engines will be able to see from your website."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 252.64000000000001,
+      "end": 257.6,
+      "text": " So to address all these problems in the last few years, this trend of building UIs has evolved a"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 257.6,
+      "end": 262,
+      "text": " little bit, and it seems like we are going back to server-side rendering. So what we used to do"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 262,
+      "end": 267.04,
+      "text": " in the times of PHP, Ruby or Rails, Django, basically you always have a server that's"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 267.04,
+      "end": 271.92,
+      "text": " generating all the HTML, all the JavaScript, CSS for your websites, and you can generate all of"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 271.92,
+      "end": 276.08000000000004,
+      "text": " that stuff dynamically. So whenever you need to read data from a database, your server will do"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 276.08000000000004,
+      "end": 280,
+      "text": " that, compile the final page for the user, and then send all the assets to that."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 280,
+      "end": 284.8,
+      "text": " So in the JavaScript space, there are some new tools that have emerged to try to satisfy this"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 284.8,
+      "end": 290.08,
+      "text": " need, and probably one of the main ones is Next.js. And Next.js basically allows you to do"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 290.08,
+      "end": 294.40000000000003,
+      "text": " everything still with JavaScript. So you will be able to use, for instance, if you like React,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 294.40000000000003,
+      "end": 299.2,
+      "text": " you will be able to use React components both on the client-side and the server-side. And Next.js"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 299.2,
+      "end": 304,
+      "text": " gives you an experience, a development experience, where it's easy to perform actions on the server"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 304,
+      "end": 308.32,
+      "text": " and pre-generate content, ship that content directly to the user, so it's going to be loaded"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 308.32,
+      "end": 313.04,
+      "text": " very quickly. And then whenever you need to do something client-side, you can still use all the"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 313.04,
+      "end": 317.44,
+      "text": " tools that you generally use with React and do client-side stuff. So it's kind of an hybrid,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 317.44,
+      "end": 321.36,
+      "text": " where in the same application, you can define all the backend logic and the frontend logic,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 321.36,
+      "end": 326.56,
+      "text": " and wherever you need to share components, Next.js makes it very easy. Now, Next.js is an open source"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 326.56,
+      "end": 330.56,
+      "text": " project that is built and maintained by Vercel. And of course, Vercel has an interest in that"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 330.56,
+      "end": 335.36,
+      "text": " project because they have a commercial offering where they make it very, very easy to host Next.js"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 335.36,
+      "end": 340.08000000000004,
+      "text": " projects and more. And we think that their experience is actually very interesting."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 340.08,
+      "end": 345.2,
+      "text": " So maybe we should talk a little bit more about that, just to see how this tool announced by AWS"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 345.2,
+      "end": 349.12,
+      "text": " compares to that kind of experience."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 349.12,
+      "end": 355.12,
+      "text": " The number one thing that you'd think about when you think about Vercel is probably the developer experience. And that involves how easy is it to get up and"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 355.12,
+      "end": 360.96,
+      "text": " running and deploy your first application and keep it running. And the zero-config nature of Vercel"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 360.96,
+      "end": 364.96,
+      "text": " is probably one of its best selling points because it's just very easy to connect your GitHub repo"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 364.96,
+      "end": 370.32,
+      "text": " and have something deployed in a couple of minutes. It doesn't just limit itself to Next.js"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 370.32,
+      "end": 374.88,
+      "text": " as well. It supports many other frameworks out of the box. And when you deploy it, you get the"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 374.88,
+      "end": 380.47999999999996,
+      "text": " automated deployment from your repo, but you also get custom domains and your HTTPS certificates"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 380.47999999999996,
+      "end": 385.52,
+      "text": " are going to be provisioned for you. And then it'll also scale on demand for you. So it's"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 385.52,
+      "end": 389.28,
+      "text": " using other cloud providers under the hood, including AWS, and it's managing all of the"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 389.28,
+      "end": 395.03999999999996,
+      "text": " scalability. But as well as just scaling within regions on cloud providers, it's also edge"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 395.03999999999996,
+      "end": 400.23999999999995,
+      "text": " optimized. So it's doing edge up deployments as well to various CDNs and running a lot of those"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 400.23999999999995,
+      "end": 405.28,
+      "text": " server actions and server component rendering on the edge for low latency. One of the really"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 405.28,
+      "end": 409.44,
+      "text": " cool things is that if you're working with branches, it will give you preview deployments"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 409.44,
+      "end": 413.52,
+      "text": " from your branches. So this means that right away, when you create a feature branch or a fixed branch,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 413.52,
+      "end": 417.35999999999996,
+      "text": " and you're working on something, you immediately get a preview URL that you can share with"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 417.36,
+      "end": 422.72,
+      "text": " stakeholders. And one of the cool features of that is that your participants can annotate"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 422.72,
+      "end": 427.52000000000004,
+      "text": " and make comments in line in your preview environment. So you can iterate really quickly"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 427.52000000000004,
+      "end": 432.56,
+      "text": " with feedback. It also has a whole set of other integrations with other products like databases,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 432.56,
+      "end": 436.32,
+      "text": " you can get a Postgres database up and running pretty quickly. You get logs,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 436.32,
+      "end": 442.48,
+      "text": " they've been putting a lot of investment into AI support recently, CMS integration, and also other"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 442.48,
+      "end": 447.68,
+      "text": " things like analytics and important security aspects as well. So there's a whole lot to love"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 447.68,
+      "end": 452.48,
+      "text": " about Vercel, but they're not a sponsor of this episode. So while we like the developer experience"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 452.48,
+      "end": 456.72,
+      "text": " and the feature set, it's still a software as a service, and you have a build or buy decision,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 456.72,
+      "end": 461.52000000000004,
+      "text": " and you have to evaluate the vendor on their own merits. If you want some more control autonomy"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 461.52000000000004,
+      "end": 466.48,
+      "text": " around the infrastructure, you might want to deploy it to your own AWS account. And Vercel"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 466.48,
+      "end": 470.64000000000004,
+      "text": " isn't something that will allow you to do that. So if you use Vercel, you don't have a lot of"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 470.64,
+      "end": 475.76,
+      "text": " visibility into how your code is deployed and where it's going under the hood. And especially"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 475.76,
+      "end": 480.24,
+      "text": " in the context of working with enterprise organizations, there are a lot of good reasons"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 480.24,
+      "end": 486.32,
+      "text": " to avoid Vercel and to host front end applications yourself directly on AWS. So where do we start?"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 486.32,
+      "end": 490.15999999999997,
+      "text": " If we want to host a front end on AWS, this is something that we've talked about a lot. It's a"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 490.15999999999997,
+      "end": 495.68,
+      "text": " bit of a bugbear of ours, I suppose, just trying to find the right most optimal way to host static"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 495.68,
+      "end": 500.15999999999997,
+      "text": " websites. We covered it in one of the very first episodes, episode three, how do you deploy a static"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 500.16,
+      "end": 505.36,
+      "text": " website on AWS? And then back in episode 80, we were talking specifically about private static"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 505.36,
+      "end": 510.32000000000005,
+      "text": " websites for enterprises. And there was always, it's always a trade off, no clear winner there."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 510.32000000000005,
+      "end": 515.28,
+      "text": " But now AWS has announced a new open source tool to help you tackle this problem. And this is the"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 515.28,
+      "end": 520,
+      "text": " CloudFront hosting toolkit. So this certainly got a lot of people's attention, a lot of people"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 520,
+      "end": 525.0400000000001,
+      "text": " talking because just you only have to mention Vercel competitor to get people's ears pricked"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 525.04,
+      "end": 531.52,
+      "text": " up. And Luciano, you've been good enough to take a good look at this for us. So maybe your best"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 531.52,
+      "end": 537.04,
+      "text": " place to give us an introduction, what is this CloudFront hosting toolkit and what can we do"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 537.04,
+      "end": 541.04,
+      "text": " with it?"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 541.04,
+      "end": 546.56,
+      "text": " Yeah, if you look at the announcement blog post, we will have a link in the show notes, they describe this tool as an open source command line interface to help you deploy fast and secure"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 546.56,
+      "end": 551.4399999999999,
+      "text": " front ends in the cloud. So that kind of tells you what is the ambition of the tool. And the idea is"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 551.44,
+      "end": 555.0400000000001,
+      "text": " to try to remove as much as possible the complexity of setting up everything you need"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 555.0400000000001,
+      "end": 561.2800000000001,
+      "text": " to run your own front end on AWS. So you have a CLI, you run the CLI, it can, once you install it"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 561.2800000000001,
+      "end": 564.6400000000001,
+      "text": " and run it against your particular repository where you are building your own front end,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 564.6400000000001,
+      "end": 569.6,
+      "text": " it can detect the framework of choice. For instance, Next.js is one of the supported ones."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 569.6,
+      "end": 573.5200000000001,
+      "text": " And at that point, it can start to generate configuration for you, for instance, recognizing"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 573.5200000000001,
+      "end": 578.72,
+      "text": " how do you build for this particular front end. It integrates with your repository. Right now,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 578.72,
+      "end": 584,
+      "text": " it supports GitHub. And basically what it does, the CLI will allow you to connect your GitHub"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 584,
+      "end": 588.5600000000001,
+      "text": " with a build pipeline hosted in AWS. And also at that point, it can create all the necessary"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 588.5600000000001,
+      "end": 593.36,
+      "text": " resources. So for instance, what do you need to host a front end? You would need an S3 bucket,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 593.36,
+      "end": 598,
+      "text": " you would need the CloudFront distribution, DNS record, TLS certificates, and more. It will create"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 598,
+      "end": 602.1600000000001,
+      "text": " all of that stuff for you using infrastructure as code. So you don't really need to worry about"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 602.1600000000001,
+      "end": 606.5600000000001,
+      "text": " basically coding all these things or figuring out where to find all of the examples to put all these"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 606.56,
+      "end": 610.88,
+      "text": " things together. So that removes a lot of the friction of self-hosting your own front ends."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 610.88,
+      "end": 615.4399999999999,
+      "text": " And everything that it does, as I said, is done through infrastructure as code, and it's made very"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 615.4399999999999,
+      "end": 619.76,
+      "text": " accessible. It's still deploying through CloudFormation so you can see exactly what's"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 619.76,
+      "end": 624.0799999999999,
+      "text": " being deployed. You have configuration files that gets generated for you. So you have also"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 624.0799999999999,
+      "end": 628.88,
+      "text": " opportunities to still sticking with the same process that is given to you by the CLI. You can"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 628.88,
+      "end": 633.1999999999999,
+      "text": " tweak and configure certain things to your liking. And then even if at the end of the day, you still"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 633.2,
+      "end": 636.96,
+      "text": " want to change more, all the infrastructure is there, all the CloudFormation is there."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 636.96,
+      "end": 641.6,
+      "text": " So you can take that and do further customization if you need to. And somewhere else, I think in the"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 641.6,
+      "end": 647.2,
+      "text": " repository, they say something that to me represents the ambition of this project. And it reads us,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 647.2,
+      "end": 651.76,
+      "text": " gives you the convenience of a managed service while putting you in full control of the hosting"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 651.76,
+      "end": 657.0400000000001,
+      "text": " infrastructure and deployment pipelines to make it your own. So that's a good marketing phrase to"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 657.0400000000001,
+      "end": 661.36,
+      "text": " say, yes, we want to make it easy for you, but at the end of the day, this is your own infrastructure."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 661.76,
+      "end": 664.48,
+      "text": " You'll have access to it and you'll be able to change everything you need."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 664.48,
+      "end": 666.4,
+      "text": " You can have your cake and eat it."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 666.4,
+      "end": 671.12,
+      "text": " Something like that, yes. But now we get to the more painful notes, I guess, because yeah,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 671.12,
+      "end": 676.72,
+      "text": " just to be real, we need to say that the current state is still a version 1.0 and it's still very,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 676.72,
+      "end": 681.6,
+      "text": " very early. Well, it was announced only a few weeks ago and it's fair to say that it's still"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 681.6,
+      "end": 686,
+      "text": " very early days. So if our feedback is going to look a little bit harsh in some parts,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 686,
+      "end": 690.08,
+      "text": " at the same time, you have to think that this is an evolving project. It's only early stages,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 690.08,
+      "end": 694.8000000000001,
+      "text": " so it can only get better. So let's be fair in that sense. So if you look at the supported"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 694.8000000000001,
+      "end": 700.4000000000001,
+      "text": " feature, right now it supports everything that you need to host an SPA that is statically generated."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 700.4000000000001,
+      "end": 704.88,
+      "text": " And that is a very important note because it means that right now you cannot do any server"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 704.88,
+      "end": 708.96,
+      "text": " side rendering. By default, it doesn't support any of that. So in a way, it's still a little"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 708.96,
+      "end": 714.48,
+      "text": " bit behind the current trends. And if you use, for instance, Next.js, Next.js allows you to do"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 714.48,
+      "end": 720.64,
+      "text": " websites that are only static generated with some tweaking in the configuration and just by not"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 720.64,
+      "end": 725.36,
+      "text": " using certain specific features, you can do that. But you need to be aware that this is an existing"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 725.36,
+      "end": 729.44,
+      "text": " limitation. If you want to use this tool with Next.js, you can only use the features that are"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 729.44,
+      "end": 735.84,
+      "text": " supported with the pre-rendered static version of the website. The other feature is that, as we said,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 735.84,
+      "end": 740.72,
+      "text": " integrates really well with GitHub for version control. It's going to do for you atomic and"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 740.72,
+      "end": 745.84,
+      "text": " immutable Eastern deploys on CloudFront. We'll talk a little bit more about that later. It's a"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 745.84,
+      "end": 750.1600000000001,
+      "text": " pretty cool implementation. So I think it's worth spending some time on how all of that works."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 750.1600000000001,
+      "end": 756.08,
+      "text": " It's a CLI tool, so very easy to install with NPM, very easy to run it in any new project. It takes"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 756.08,
+      "end": 760.88,
+      "text": " literally a few seconds just to get started. And also it does security and caching best practices."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 760.88,
+      "end": 764.88,
+      "text": " So all of these things are already incorporated in the generated infrastructure. So one less"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 764.88,
+      "end": 769.12,
+      "text": " thing to worry about because if you were doing all of this yourself, maybe you get something working"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 769.12,
+      "end": 773.84,
+      "text": " after a few hours of investigation and trainings, but then at the end of the day, you might still be"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 773.84,
+      "end": 777.84,
+      "text": " unsure on whether that's something that can be production ready or not. This tool removes a"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 777.84,
+      "end": 782.16,
+      "text": " little bit of that concern because it's already following tons of best practices that have been"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 782.16,
+      "end": 786.8,
+      "text": " established in the AWS landscape for the last few years. And then it allows you to use custom"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 786.8,
+      "end": 792.64,
+      "text": " domains. So if you want to host your own front end in your own custom domain, all of that process"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 792.64,
+      "end": 798.08,
+      "text": " is streamlined. It's going to integrate with Route 53 and generate the necessary records,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 798.08,
+      "end": 802.88,
+      "text": " generate the TLS certificates for you, and make sure everything is integrated properly. If you"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 802.88,
+      "end": 807.12,
+      "text": " don't have a custom domain, it's going to use a CloudFront domain for you. And finally, there is"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 807.12,
+      "end": 812.64,
+      "text": " also a CDK level three construct for the toolkit that can be used as an alternative for the CLI."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 812.64,
+      "end": 817.12,
+      "text": " So that's maybe another option if you prefer to go more with something that is integrated with your"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 817.12,
+      "end": 822.96,
+      "text": " own CDK rather than using the CLI. But I mentioned atomic and immutable instant deploys, which is a"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 822.96,
+      "end": 827.36,
+      "text": " little bit of a mouthful. So do we want to try to explain what that really is and how it is"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 827.36,
+      "end": 832.5600000000001,
+      "text": " implemented? Yeah, it's pretty neat."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 832.5600000000001,
+      "end": 837.52,
+      "text": " It uses CloudFront functions and CloudFront key value store, which you may not have come across. Let's go through these fundamental pieces of CloudFront"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 837.52,
+      "end": 843.12,
+      "text": " first. So CloudFront functions are a little bit like CloudFlare workers, I guess, or other edge"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 843.12,
+      "end": 847.52,
+      "text": " functions that you might've come across. They're like a much simpler version of Lambda because you"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 847.52,
+      "end": 853.12,
+      "text": " also have Lambda at the edge, but Lambda at the edge is more like a fully fledged Lambda,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 853.12,
+      "end": 858.96,
+      "text": " although not quite. CloudFront functions are just more like lightweight JavaScript isolated"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 858.96,
+      "end": 864.96,
+      "text": " contexts that are much more efficient, but also restricted in terms of what packages you can use"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 864.96,
+      "end": 869.84,
+      "text": " and that sort of thing. So you could use CloudFront functions for writing lightweight functions for"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 870.4,
+      "end": 877.92,
+      "text": " high-scale latency-sensitive CDN customizations like redirects or request response modification,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 878.4,
+      "end": 883.5999999999999,
+      "text": " URL rewrites, that sort of thing. And then you have CloudFront key value store. And this is a"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 883.5999999999999,
+      "end": 888.8,
+      "text": " bit like a simplified version of DynamoDB that runs on the edge. And we've seen this kind of"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 888.8,
+      "end": 896,
+      "text": " service from CloudFront, sorry, from CloudFlare as well. It's a global low latency key value store,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 896,
+      "end": 901.76,
+      "text": " and it allows you to read from CloudFront functions. And by having that state in your"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 901.76,
+      "end": 907.28,
+      "text": " key value store, you can do more customizable logic at the edge functions. So when you have"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 907.36,
+      "end": 913.1999999999999,
+      "text": " CloudFront key value store, you can make updates to function code and updates to the data associated"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 913.1999999999999,
+      "end": 918.16,
+      "text": " with the function independently of each other. This kind of separation will simplify your"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 918.16,
+      "end": 922.16,
+      "text": " functions code and makes it easy to update data without the need to deploy code changes."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 923.04,
+      "end": 927.52,
+      "text": " Now, when it comes back to this CloudFront hosting toolkit, the basic idea is that every time you"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 927.52,
+      "end": 932.8,
+      "text": " want to deploy a new version of your front end, rather than replacing the entire content of the"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 932.8,
+      "end": 938,
+      "text": " S3 bucket hosting your assets or overwriting, you'll create a new unique deployment ID and"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 938,
+      "end": 943.12,
+      "text": " host all the files for a deployment version in a dedicated prefix, like a subfolder. So let's say"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 943.12,
+      "end": 947.28,
+      "text": " your first deployment ID is version one, then it'll create a prefix like slash version one."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 947.28,
+      "end": 953.8399999999999,
+      "text": " And then within that, you'll have your index.html and your bundled JavaScript. And then with your"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 953.8399999999999,
+      "end": 958.24,
+      "text": " second deployment, it would be version two under a slash version two prefix. So when a user will"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 958.24,
+      "end": 965.6,
+      "text": " try to access a page by doing get index.html, this request goes to CloudFront first and the"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 965.6,
+      "end": 970.32,
+      "text": " CloudFront function is the first bit of logic that gets evaluated. It can go to the CloudFront"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 970.32,
+      "end": 974.48,
+      "text": " key value store to read the ID of the latest deployed version. And the function will then"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 974.48,
+      "end": 980.08,
+      "text": " rewrite the URL to point to the specific assets in the S3 origin for that current version."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 980.08,
+      "end": 985.84,
+      "text": " So if you're going, making a request to get slash about that would become get slash version two"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 986.1600000000001,
+      "end": 991.6800000000001,
+      "text": " slash about dot html, for example. So then it'll load that specific asset from S3 or cache and"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 991.6800000000001,
+      "end": 995.44,
+      "text": " return it to the user. And then when you have a new deployment, it'll just create a new prefix"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 995.44,
+      "end": 1000,
+      "text": " in S3 to host all those assets. When all is done, the new version ID is stored in that key value"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1000,
+      "end": 1003.84,
+      "text": " store. And the next time somebody is accessing the website, they'll get the latest version. Now,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1003.84,
+      "end": 1007.9200000000001,
+      "text": " there's a few nice things about this approach. It's an immutable deployment approach, which means"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1007.9200000000001,
+      "end": 1012.88,
+      "text": " that every deployment is clean and new, and you can troubleshoot it in its own space. But you also"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1012.96,
+      "end": 1017.92,
+      "text": " retain older versions, which would make it easy to do rollbacks if you have to do that. There is"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1017.92,
+      "end": 1021.84,
+      "text": " little risk then that a user will receive assets from different versions, which is a common problem"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1021.84,
+      "end": 1027.44,
+      "text": " if you're just kind of overwriting into a single prefix in S3 or if they're accessing the website"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1027.44,
+      "end": 1033.12,
+      "text": " during an update. The other nice thing about this is that it could easily support preview"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1033.12,
+      "end": 1037.44,
+      "text": " environments. But we haven't seen anything showing that this is supported yet in CloudFront hosting"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1037.44,
+      "end": 1042.56,
+      "text": " toolkit, but it seems like this kind of architecture would certainly enable it. So"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1042.56,
+      "end": 1047.92,
+      "text": " maybe let's talk about your real world practice. You've taken it for a good test drive CloudFront"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1047.92,
+      "end": 1052.16,
+      "text": " hosting toolkit, and you've had some successes and some bumps in the road Luciano."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1052.16,
+      "end": 1054.8,
+      "text": " Luciano Yes."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1054.8,
+      "end": 1061.52,
+      "text": " So I'm going to try to describe the steps that I performed to try to test this tool and the different things that I found out."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1061.52,
+      "end": 1065.68,
+      "text": " And hopefully that can give you an idea of how the tool works, the kind of developer experience"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1065.76,
+      "end": 1071.2,
+      "text": " you get and what gets created for you behind the scenes. So I started with a plain vanilla Next.js"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1071.2,
+      "end": 1076.96,
+      "text": " project. There is one CLI command that you can find in the Next.js documentation that basically"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1076.96,
+      "end": 1082.96,
+      "text": " uses a starter kit. And that starter kit is just a simple repo where you have a one Next.js page"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1082.96,
+      "end": 1088.5600000000002,
+      "text": " that points you to the documentation, to the about page and a few other simple things. So effectively"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1088.5600000000002,
+      "end": 1093.52,
+      "text": " it's like one page application, and it's like a static, statically renderable application because"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1093.52,
+      "end": 1098,
+      "text": " it doesn't really do any server side action or anything like that. So you run this first command,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1098,
+      "end": 1102.72,
+      "text": " this command will do all the scaffolding for you. At that point, you can do npm install to install"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1102.72,
+      "end": 1107.36,
+      "text": " the dependencies. And if you want to run your frontend locally, just to see it running and play"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1107.36,
+      "end": 1112.6399999999999,
+      "text": " around with it, you can just say npm run dev, and that will give you locally an environment that you"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1112.6399999999999,
+      "end": 1116.8799999999999,
+      "text": " can use to tweak things around. Then at some point you are maybe happy with it and you want to try to"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1116.8799999999999,
+      "end": 1121.44,
+      "text": " deploy it using this CloudFront hosting toolkit. The first thing you need to do is install the"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1121.44,
+      "end": 1126.64,
+      "text": " toolkit itself. We said it's a CLN application, it's built with Node.js. So of course Node.js"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1126.64,
+      "end": 1132.8,
+      "text": " becomes a requirement at that point. But once you do that, you can easily install with MPX or just"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1132.8,
+      "end": 1139.6000000000001,
+      "text": " by doing an npm install global of the art AWS slash CloudFront dash hosting dash toolkit. And"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1139.6000000000001,
+      "end": 1144.24,
+      "text": " that will basically pull the latest version of the toolkit for you in your local development"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1144.24,
+      "end": 1148.16,
+      "text": " environment. Now the idea is that you need to use it against an existing repository. So this is why"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1148.16,
+      "end": 1154,
+      "text": " I created an XJS project first. Once I did all of that and I was happy with the outcome, then you"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1154,
+      "end": 1159.76,
+      "text": " can start the tool. And the way you start the tool, you go with your CLI into the specific folder where"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1159.76,
+      "end": 1164.88,
+      "text": " you have your frontend application and you just run CloudFront dash hosting dash toolkit space"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1164.88,
+      "end": 1170.16,
+      "text": " init. That's literally the one command you need to run. And at that point, you have a guided process"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1170.16,
+      "end": 1175.1200000000001,
+      "text": " that will effectively ask you some questions to try to understand how to deploy this project for"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1175.12,
+      "end": 1179.28,
+      "text": " you. And the first question that it's going to ask is what is your repository? And of course,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1179.28,
+      "end": 1184.4799999999998,
+      "text": " it's going to be able to auto detect it from the current working folder. If you have already"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1184.4799999999998,
+      "end": 1188.8,
+      "text": " initialized that as a Git repository and it's hosted on GitHub, it's going to automatically"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1188.8,
+      "end": 1192.8799999999999,
+      "text": " complete that particular question. But you can change it if you have different requirements,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1192.8799999999999,
+      "end": 1197.4399999999998,
+      "text": " or maybe if you haven't set up the repo yet locally, you can still point it to a repo that"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1197.4399999999998,
+      "end": 1202.1599999999999,
+      "text": " you have set up already remotely on GitHub. The next step is going to ask you the name of the"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1202.16,
+      "end": 1207.8400000000001,
+      "text": " branch for deployments. It defaults to main, but I think you can use this if you want to change that"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1207.8400000000001,
+      "end": 1212.5600000000002,
+      "text": " to something else. Maybe you want to have a branch called deployment or deploy that you specifically,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1212.5600000000002,
+      "end": 1216.4,
+      "text": " when you want to trigger a deploy, you can decide which branch is actually going to trigger the"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1216.4,
+      "end": 1221.44,
+      "text": " deployments that way. The next question is what is your framework of choice? And here, you have a few"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1221.44,
+      "end": 1227.2,
+      "text": " frameworks that are supported. AngularJS, Next.js, React, Vue.js. There is another one which is"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1227.2,
+      "end": 1231.68,
+      "text": " no build required, which basically means everything that is in the main folder is going to"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1231.68,
+      "end": 1237.04,
+      "text": " be deployed. And I think this is for static websites that don't require a build process. Maybe"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1237.04,
+      "end": 1241.8400000000001,
+      "text": " you just created a few simple HTML, CSS, and JavaScript files. You have them there and you just"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1241.8400000000001,
+      "end": 1246.0800000000002,
+      "text": " want to deploy them. The cool thing here is that it was able to automatically detect that I was"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1246.0800000000002,
+      "end": 1251.68,
+      "text": " using Next.js. So that option was already selected for me. I just needed to hit enter and proceed."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1251.68,
+      "end": 1256.64,
+      "text": " But of course, you can change that if maybe it's not able to detect your framework, or maybe you"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1256.64,
+      "end": 1260.96,
+      "text": " are actually using something else and it didn't really detect it correctly. The next step is"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1261.6000000000001,
+      "end": 1267.2,
+      "text": " asking you if you want to use a specific domain name, or if you want to use the default CloudFront"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1267.2,
+      "end": 1271.92,
+      "text": " domains. In this particular case, I didn't have a domain, so I just went with the CloudFront one,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1271.92,
+      "end": 1276.4,
+      "text": " which maybe is a little bit of a simpler path. I'd be curious to try it again with a custom domain,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1276.4,
+      "end": 1281.1200000000001,
+      "text": " just to see all the extra resources that it needs to create to support that. But I haven't done that"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1281.1200000000001,
+      "end": 1285.2800000000002,
+      "text": " yet. Once you've done all of this, this is basically the initial setup. So it's basically"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1285.28,
+      "end": 1290.24,
+      "text": " making sure that it understands your project and the configuration of your project. But at that"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1290.24,
+      "end": 1294.16,
+      "text": " point, it can start to generate things for you. And it's interesting to see that it generates a"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1294.16,
+      "end": 1299.44,
+      "text": " folder called the CloudFront-hosting-toolkit. And in this folder, it will generate three files for"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1299.44,
+      "end": 1304.16,
+      "text": " you. The first file is a code build job configuration. So it's basically the YAML file"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1304.16,
+      "end": 1308.32,
+      "text": " that contains all of that configuration. And this is awesome because that means that if you want to"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1308.32,
+      "end": 1312.8,
+      "text": " change anything in the pre-generated build step, because it's kind of assuming, okay, this is a"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1312.8,
+      "end": 1317.9199999999998,
+      "text": " Next.js project. I know how to build a Next.js project, but maybe you have additional requirements."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1317.9199999999998,
+      "end": 1322,
+      "text": " Maybe you want to do additional things that are not the standard way of building an Next.js website."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1322,
+      "end": 1327.28,
+      "text": " You can easily change all the steps and customize it to your liking without having to change the"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1327.28,
+      "end": 1331.76,
+      "text": " toolkit or having to change anything else in the infrastructure as code. So it's just this one file"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1331.76,
+      "end": 1336.56,
+      "text": " allows you to change things. It also generates in this folder the CloudFront function that is used"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1336.56,
+      "end": 1341.84,
+      "text": " for URL rewriting, the one you described before, Eoin. And you can see all the JavaScript code that"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1341.84,
+      "end": 1346.6399999999999,
+      "text": " is being generated. So also there, you have an opportunity to change things around. Maybe you can,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1346.6399999999999,
+      "end": 1351.04,
+      "text": " I don't know, add some extra logic to check if there is a query string parameter that says"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1351.04,
+      "end": 1356,
+      "text": " version equals something. Maybe you can actually enable that feature preview that way and by"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1356,
+      "end": 1359.6,
+      "text": " yourself, assuming that it's not supported yet. But basically, this is just to tell you that you"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1359.6,
+      "end": 1363.84,
+      "text": " have one file with all the logic that are visible. It's easy to change. And if you change it, this is"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1363.84,
+      "end": 1368.56,
+      "text": " what's going to get deployed for you. And then finally, there is a generic JSON file that contains"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1368.56,
+      "end": 1374.24,
+      "text": " all the options that were requested to you in the initial init phase. So if you change your mind,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1374.24,
+      "end": 1378,
+      "text": " maybe you don't want to deploy from main anymore, you want to deploy from another branch, you can"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1378,
+      "end": 1382.8799999999999,
+      "text": " easily change that JSON file to get your base configuration updated. At that point, what you"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1382.8799999999999,
+      "end": 1389.2,
+      "text": " can do is that you can effectively deploy. At this point, you haven't deployed anything. You just"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1389.2,
+      "end": 1393.36,
+      "text": " generated these three configuration files, but those three configuration files are enough for"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1393.36,
+      "end": 1398.08,
+      "text": " you to start the deployment. So you can run another command called cloudfront-osting-toolkit"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1398.08,
+      "end": 1402,
+      "text": " space deploy. And what it's going to do is basically going to take all these three generated"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1402,
+      "end": 1407.04,
+      "text": " files as an input, and it's going to create all the necessary cloud formation templates to deploy"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1407.04,
+      "end": 1411.76,
+      "text": " everything else that we described before. So it's three buckets, cloud front, the distributions,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1411.76,
+      "end": 1416.4799999999998,
+      "text": " the cloud front function, the cloud front key value storage, and there is a lot more. You can"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1416.4799999999998,
+      "end": 1421.1999999999998,
+      "text": " check out, there is a diagram in the announcement page and in the repository showing exactly all the"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1421.2,
+      "end": 1425.28,
+      "text": " resources that get created and how they are related to each other. And this is also going"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1425.28,
+      "end": 1429.8400000000001,
+      "text": " to do a few other things. So initially it's going to bootstrap your AWS account, which I think it"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1429.8400000000001,
+      "end": 1434.32,
+      "text": " means it's going to create a dedicated street bucket for the deployments. It's going to create"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1434.32,
+      "end": 1438.48,
+      "text": " the repository, the CodeStar integration. And actually the CodeStar integration is really"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1438.48,
+      "end": 1442.96,
+      "text": " interesting because what it does the first time you need to manually confirm that connection"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1442.96,
+      "end": 1447.6000000000001,
+      "text": " between your GitHub account and AWS. And it's something that you have to do in a browser where"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1447.6,
+      "end": 1452.1599999999999,
+      "text": " you are effectively authenticated on both sides. So what it's going to do is going to generate"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1452.1599999999999,
+      "end": 1456.8,
+      "text": " the request for you. Then it's going to redirect you to the AWS console and in the AWS console,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1456.8,
+      "end": 1461.76,
+      "text": " you can click to basically connect your own GitHub account. To be honest, this was amazing to see on"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1461.76,
+      "end": 1465.6799999999998,
+      "text": " one side, but on the other side, in my case, it was a little bit annoying because I use,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1465.6799999999998,
+      "end": 1470.48,
+      "text": " when I access to AWS, I generally use anonymous sessions because I might have sessions for"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1470.48,
+      "end": 1474.32,
+      "text": " different AWS accounts. So when I was trying to connect to GitHub, it didn't have my own"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1474.3999999999999,
+      "end": 1479.84,
+      "text": " credentials. And it took me a while to connect into that anonymous environment with GitHub,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1479.84,
+      "end": 1485.36,
+      "text": " asking you MFA and confirmation by email, just because they see that it's a different session"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1485.36,
+      "end": 1489.9199999999998,
+      "text": " that you haven't used before. But eventually I managed to get it working. And then all the"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1489.9199999999998,
+      "end": 1496.24,
+      "text": " local setup was done. The remote setup was done on AWS. And you just need to click enter to say"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1496.24,
+      "end": 1501.9199999999998,
+      "text": " that you successfully connected GitHub with AWS. And then at that point it's going to proceed with"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1501.92,
+      "end": 1506.8000000000002,
+      "text": " the cloud formation deployment. Now, at this point, I had a problem because once everything"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1506.8000000000002,
+      "end": 1511.92,
+      "text": " is deployed for you, it's also going to try to run the code build for the first time and try to do a"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1511.92,
+      "end": 1516,
+      "text": " first deployment of your front-end application. Like if you were doing your first commit,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1516,
+      "end": 1521.44,
+      "text": " basically. And that one actually failed because there is an issue with the version of Next.js"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1521.44,
+      "end": 1526.48,
+      "text": " that I'm using. I'm using the very latest version and that latest version doesn't support Next"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1526.48,
+      "end": 1532.4,
+      "text": " export, which is what the default build pipeline is using to create the static version of the"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1532.4,
+      "end": 1537.3600000000001,
+      "text": " website. Now, this is something you can easily fix. You just need to create a Next config.js file,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1537.3600000000001,
+      "end": 1541.52,
+      "text": " do the modern way of saying that you want to produce a static website, which is just like"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1541.52,
+      "end": 1545.84,
+      "text": " one option, I think it's export static or something like that. Commit that into your own"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1545.84,
+      "end": 1551.04,
+      "text": " repository. And of course you also need to update the code build pipeline, not to use Next export"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1551.04,
+      "end": 1555.68,
+      "text": " anymore, because at that point, when you do Next build, it's already creating the final version of"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1555.68,
+      "end": 1559.92,
+      "text": " your website for deployment. And this is basically where I stopped, but I could see that everything"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1559.92,
+      "end": 1564.3200000000002,
+      "text": " was generated correctly. I could see that if I was doing another commit, the build pipeline would"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1564.3200000000002,
+      "end": 1568.96,
+      "text": " trigger automatically and do all of the deployment we described. So I think even though there are"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1568.96,
+      "end": 1573.68,
+      "text": " some steps that might be a little bit annoying, overall, that experience was quite pleasant."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1573.68,
+      "end": 1578.0800000000002,
+      "text": " I don't know what you think so far, and if you have any final consideration on your end."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1578.1599999999999,
+      "end": 1582.8799999999999,
+      "text": " You know, we talked about this kind of stuff when we were talking about CDK in previous episodes."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1582.8799999999999,
+      "end": 1588.8799999999999,
+      "text": " I personally have a bias against code, sorry, against tools that generate code that introduce"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1588.8799999999999,
+      "end": 1593.12,
+      "text": " another level of abstraction, mainly because it's just another, you have to understand kind of"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1593.12,
+      "end": 1597.6,
+      "text": " what's going on under the hood, and then also what's happening in this abstraction layer. And"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1597.6,
+      "end": 1601.28,
+      "text": " if, especially with a tool like this that might not be perfectly stable yet, you might wonder,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1601.28,
+      "end": 1606,
+      "text": " will it suddenly generate a completely different set of infrastructure that might make it difficult"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1606,
+      "end": 1611.2,
+      "text": " to do seamless upgrades? And I'd much prefer to spend the time to provision all of the"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1611.2,
+      "end": 1616.72,
+      "text": " infrastructure myself and really understand it more often than not. But I can certainly see"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1616.72,
+      "end": 1621.28,
+      "text": " the value in it, because I have been in a case recently where I've been trying to deploy a static"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1621.28,
+      "end": 1626.4,
+      "text": " version, like a SPA version of an XJS app, with only client-side rendering, with static export"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1626.4,
+      "end": 1631.92,
+      "text": " to CloudFront, and it's definitely not a trivial thing. So I think there's, I definitely commend"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1631.92,
+      "end": 1637.52,
+      "text": " the effort here to get all of this stuff working. It's not an easy thing to do, and it does provide"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1637.52,
+      "end": 1643.2,
+      "text": " like a good blueprint for people to get started with it. So while my bias isn't necessarily drawn"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1643.2,
+      "end": 1648.24,
+      "text": " to a tool like this, I think it is pretty promising. I think there's some really good"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1648.24,
+      "end": 1652.16,
+      "text": " ideas in here, like the immutable deployments, and it seems to be simple enough to use. There's"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1652.16,
+      "end": 1656,
+      "text": " obviously some rough edges that need to be polished. The fact that it doesn't support"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1656,
+      "end": 1660.0800000000002,
+      "text": " server-side rendering may be a bit of a blocker for a lot of people at this point. Let's hope"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1660.08,
+      "end": 1666.08,
+      "text": " we'll see a bit of evolution there. I mean, I kind of think back to one of the previous"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1666.08,
+      "end": 1670.8799999999999,
+      "text": " releases from AWS we covered, which was the integration testing toolkit, the IITK,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1670.8799999999999,
+      "end": 1675.84,
+      "text": " and it was also a similar kind of review, like a lot of promising stuff, but needs more work."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1675.84,
+      "end": 1680.1599999999999,
+      "text": " And when I went back to look at that recently, because I did use it in a side project,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1681.04,
+      "end": 1686.6399999999999,
+      "text": " it doesn't seem to have actually evolved that much. So I know, we know that AWS likes to"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1686.64,
+      "end": 1691.1200000000001,
+      "text": " release things early and get feedback from the user base, but let's hope that this one"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1691.1200000000001,
+      "end": 1694.48,
+      "text": " sees the love and attention that we need. What's your take?"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1694.48,
+      "end": 1698.8000000000002,
+      "text": " Yeah, I absolutely agree with everything you said."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1698.8000000000002,
+      "end": 1704.88,
+      "text": " A few things that I can mention in addition to that is that I was able to fix an initial issue that I had with the CLI not"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1704.88,
+      "end": 1710.48,
+      "text": " installing properly. So I just submitted a PR and I was impressed to see how quickly I got a review."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1710.48,
+      "end": 1717.2,
+      "text": " The PR was properly commented and released and very quickly all happened in the span of an hour."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1717.2,
+      "end": 1722,
+      "text": " And the problem was fixed immediately. The maintainer was extremely welcoming. So that's"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1722,
+      "end": 1726.96,
+      "text": " definitely a good thing to see. And I think that creates a big opportunity for everyone that wants"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1726.96,
+      "end": 1731.52,
+      "text": " to contribute to this kind of project to be able to do that. It seems really like a very welcoming"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1731.52,
+      "end": 1736.08,
+      "text": " environment for people to contribute. So maybe if the tool doesn't have all the things you need"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1736.08,
+      "end": 1740.16,
+      "text": " and you are willing to invest a little bit on it, definitely think about contributing and"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1740.16,
+      "end": 1744.16,
+      "text": " giving back and working with the maintainer to get to the point where this tool is actually"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1744.16,
+      "end": 1749.44,
+      "text": " going to be helpful for you and for other people. So that's absolutely a plus one for the tool and"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1749.44,
+      "end": 1754.48,
+      "text": " the current maintaining team. Another thing that I think is worth mentioning is that there is another"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1754.48,
+      "end": 1759.2,
+      "text": " walkthrough by our friend Sandro Volpicella. We will have the link in the show notes. He has also"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1759.2,
+      "end": 1764.0800000000002,
+      "text": " done a similar kind of test ride of the tool and wrote a blog post detailing all the things that"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1764.0800000000002,
+      "end": 1768.0800000000002,
+      "text": " he found out. I think there is even a few more things that he explains. Like for instance,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1768.08,
+      "end": 1771.9199999999998,
+      "text": " there is a step function that is used for updating the versions and he also goes through on"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1771.9199999999998,
+      "end": 1776.24,
+      "text": " how that works and why it needs to be there and maybe how it can be improved. So if you want to"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1776.24,
+      "end": 1780.1599999999999,
+      "text": " do an additional deep dive on the technology and get another perspective on the tool,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1780.1599999999999,
+      "end": 1784.3999999999999,
+      "text": " definitely recommend to read that blog post. And then finally, I think it's worth mentioning a"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1784.3999999999999,
+      "end": 1788.8,
+      "text": " few potential alternatives because we are effectively working with a customer that might"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1788.8,
+      "end": 1793.12,
+      "text": " need this kind of stuff. So we are doing lots of research on what are the possible options there."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1793.12,
+      "end": 1797.28,
+      "text": " And it's also a topic we are really passionate about. As you can see, we keep talking about this."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1798.08,
+      "end": 1802.1599999999999,
+      "text": " So other things that we think are going to be suitable, for instance, you can more or less"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1802.1599999999999,
+      "end": 1806.6399999999999,
+      "text": " relatively easy, you should be able to create a container and then run that container with a Next"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1806.6399999999999,
+      "end": 1811.4399999999998,
+      "text": " JS application with full server-side rendering either on a Prunner or Fargate. But then of course,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1811.4399999999998,
+      "end": 1815.52,
+      "text": " you have something that is running 24 seven. So maybe not necessarily what you want to do if you"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1815.52,
+      "end": 1819.6799999999998,
+      "text": " want a more serverless approach. And in that front, there is another project that seems very"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1819.6799999999998,
+      "end": 1825.12,
+      "text": " promising that is called OpenNext, which we haven't tried yet, but in the docs, it says that it also"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1825.12,
+      "end": 1830.7199999999998,
+      "text": " supports server-side rendering on Lambda. So that seems maybe a closer re-implementation of what"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1830.7199999999998,
+      "end": 1835.52,
+      "text": " Vercel does for you, but that you can deploy on your own on AWS. It's definitely worth a look."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1835.52,
+      "end": 1840.1599999999999,
+      "text": " And hopefully we will have time to try it out and maybe give you an overview of what that looks like."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1840.1599999999999,
+      "end": 1844.32,
+      "text": " Similarly, there is another project called Coolify, which is a little bit more generic."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1844.9599999999998,
+      "end": 1850.6399999999999,
+      "text": " It's probably a modern take on Heroku. So it allows you to host your own bus and it does that"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1850.64,
+      "end": 1856.24,
+      "text": " in a serverless way. But as such, you should be able to host a container that you can run with"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1856.24,
+      "end": 1860.5600000000002,
+      "text": " everything you need to run an Next JS project. So another thing that we really like to try,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1860.5600000000002,
+      "end": 1865.2,
+      "text": " we haven't had the time yet, but if we do try it, we'll let you know our findings. And finally,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1865.2,
+      "end": 1870.24,
+      "text": " there is Amplify, which always gets mentioned every time that people talk about Vercel versus"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1870.24,
+      "end": 1874.88,
+      "text": " AWS. I don't personally have an opinion on that one because I haven't really used Amplify much."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1874.88,
+      "end": 1878.5600000000002,
+      "text": " So, oh, and I'll leave it to you to mention something about Amplify if you want."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1878.6399999999999,
+      "end": 1881.84,
+      "text": " I've looked at, you know, I don't have a huge amount of experience either."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1881.84,
+      "end": 1887.9199999999998,
+      "text": " I've used the Amplify CLI and the client SDK a lot. The managed side of Amplify is a whole other set of features."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1887.9199999999998,
+      "end": 1894.72,
+      "text": " Like they allow you to easily provision storage and hosting and all sorts of other stuff. I know"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1894.72,
+      "end": 1900.32,
+      "text": " that they've introduced a new generation two, and I'd love to do an episode on that in the future."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1900.8799999999999,
+      "end": 1905.52,
+      "text": " But from what I can see with the new generation two Amplify, it's also solving the same sort of"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1905.52,
+      "end": 1910.56,
+      "text": " problem in a much more managed service kind of way. So it seems a little bit more like an AWS"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1910.56,
+      "end": 1916.96,
+      "text": " managed Vercel alternative. And I think from what I've seen so far, a lot of work has gone into"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1916.96,
+      "end": 1920.48,
+      "text": " that. I haven't tried it, so I don't know exactly what the experience is like. Let us know if you"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1920.48,
+      "end": 1926.24,
+      "text": " have, because I'd love to know. I have seen some online discussion. Actually Yan Shui was"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1927.2,
+      "end": 1933.04,
+      "text": " mentioning the release of the CloudFront hosting toolkit. And one of the principal essays at AWS"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1933.04,
+      "end": 1936.8,
+      "text": " was answering the question, well, why did you actually create this tool when you already have"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1936.8,
+      "end": 1941.68,
+      "text": " Amplify? And it seems like they explained pretty clearly that strategically they're basically"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1941.68,
+      "end": 1945.2,
+      "text": " saying, if you want to manage service, use Amplify. But if you want a little bit more"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1945.2,
+      "end": 1948.96,
+      "text": " control over the infrastructure and you're really just looking for something to generate that"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1948.96,
+      "end": 1954.8799999999999,
+      "text": " blueprint infrastructure, then that's what the CloudFront hosting toolkit is aimed to solve for"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1954.8799999999999,
+      "end": 1959.2,
+      "text": " you. So at least that gives you the right kind of context for deciding which approach you might like"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1959.2,
+      "end": 1962.96,
+      "text": " to take. Awesome. And I think that covers everything we wanted to cover for today."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1963.52,
+      "end": 1968.24,
+      "text": " Let us know if you had a chance to try the tool yourself and what is your opinion, or if you've"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1968.24,
+      "end": 1972.6399999999999,
+      "text": " used any other alternative tool, what do you use and whether you like it or not. I think this is"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1972.6399999999999,
+      "end": 1977.44,
+      "text": " still a topic that deserves a lot of attention. I don't think there is a final solution that is"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1977.44,
+      "end": 1983.2,
+      "text": " going to fit all the use cases. So I'm really good to see... Well, unless you use PHP and become a"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1983.2,
+      "end": 1989.12,
+      "text": " millionaire that way. But yeah, let us know what are you using today. And I'm curious to see how"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1989.12,
+      "end": 1992.32,
+      "text": " this space is going to evolve in the next few years, because I think there is still a lot of"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1992.32,
+      "end": 1996.6399999999999,
+      "text": " innovation that needs to happen in this space to fit all the different use cases that people"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1996.6399999999999,
+      "end": 2005.6799999999998,
+      "text": " have today. So thank you very much, and we'll see you in the next episode."
+    }
+  ]
+}

--- a/src/_transcripts/125.vtt
+++ b/src/_transcripts/125.vtt
@@ -1,0 +1,1677 @@
+WEBVTT
+
+1
+00:00:00.000 --> 00:00:03.120
+A couple of weeks ago, AWS announced a new open source tool,
+
+2
+00:00:03.120 --> 00:00:07.440
+CloudFront Hosting Toolkit, a new tool that promises to streamline the experience
+
+3
+00:00:07.440 --> 00:00:12.960
+of deploying front-end applications to AWS while retaining full control of the underlying infrastructure.
+
+4
+00:00:12.960 --> 00:00:17.440
+We are particularly excited about this announcement because it was recognized by some people in the community
+
+5
+00:00:17.440 --> 00:00:20.320
+as the AWS response to something like Vercel.
+
+6
+00:00:20.320 --> 00:00:24.560
+We took CloudFront Hosting Toolkit for a spin and we are eager to tell you what we found out.
+
+7
+00:00:24.560 --> 00:00:28.160
+In this episode, we'll discuss all about CloudFront and Toolkit,
+
+8
+00:00:28.160 --> 00:00:33.360
+but we will also talk about modern front-ends and what's the expectation for a modern web application these days,
+
+9
+00:00:33.360 --> 00:00:36.640
+brought from a user perspective, so visiting an application,
+
+10
+00:00:36.640 --> 00:00:39.920
+but also from a developer perspective, so building that kind of application.
+
+11
+00:00:39.920 --> 00:00:45.600
+We will then discuss CloudFront Hosting Toolkit and see how it stands against this way of seeing modern front-ends.
+
+12
+00:00:45.600 --> 00:00:50.400
+My name is Luciano and as always, I'm joined by Eoin for another episode of AWS Bites podcast.
+
+13
+00:00:58.400 --> 00:01:04.000
+AWS Bites is brought to you by fourTheorem, an AWS consulting partner with tons of experience with AWS.
+
+14
+00:01:04.000 --> 00:01:08.960
+If you need someone to help you with your ambitious AWS projects, check out fourTheorem.com.
+
+15
+00:01:08.960 --> 00:01:12.160
+You can contact us directly using the links in the show notes.
+
+16
+00:01:12.160 --> 00:01:17.360
+So maybe we can start this episode by describing what a modern front-end application looks like
+
+17
+00:01:17.360 --> 00:01:22.080
+because for many years, the golden standard of front-end application has been single page applications.
+
+18
+00:01:22.080 --> 00:01:26.320
+And if you're not familiar with that definition, a single page application is effectively,
+
+19
+00:01:26.320 --> 00:01:31.920
+you can imagine like a single HTML shell that is loaded and that shell only loads some JavaScript.
+
+20
+00:01:31.920 --> 00:01:35.760
+And inside that JavaScript, you have all the logic that your application needs.
+
+21
+00:01:35.760 --> 00:01:41.360
+So that JavaScript will do client-side routing, which basically means that once the application is loaded,
+
+22
+00:01:41.360 --> 00:01:47.200
+there is JavaScript logic that will look at the current URL and decide which components need to be mounted
+
+23
+00:01:47.200 --> 00:01:50.480
+or unmounted to effectively refresh the page dynamically.
+
+24
+00:01:50.480 --> 00:01:56.240
+It will also do client-side HTTP requests, something that has been called originally Ajax requests.
+
+25
+00:01:56.240 --> 00:01:58.880
+In the past, now it's more called fetch requests.
+
+26
+00:01:58.880 --> 00:02:03.120
+But the idea is that once the application is loaded, it doesn't really have any dynamic data,
+
+27
+00:02:03.120 --> 00:02:05.280
+something that you might keep, for instance, in a database.
+
+28
+00:02:05.280 --> 00:02:10.240
+So whenever you need to load dynamic data, you need to do HTTP requests to a backend API,
+
+29
+00:02:10.240 --> 00:02:14.160
+and that API will give you the dynamic data that then can be displayed in the page.
+
+30
+00:02:14.160 --> 00:02:18.320
+So this basically means that you can also the entire front-end as a static website
+
+31
+00:02:18.320 --> 00:02:20.960
+in something like CloudFront, for instance.
+
+32
+00:02:20.960 --> 00:02:24.240
+And the great part of all of this is that you don't need a backend at all.
+
+33
+00:02:24.240 --> 00:02:29.120
+It's just static files. The browser can load them, and all the business logic needed for your front-end
+
+34
+00:02:29.120 --> 00:02:31.840
+exists in those JavaScript files loaded by the browser.
+
+35
+00:02:31.840 --> 00:02:35.600
+And this keeps things very simple, and it can be also very cost efficient,
+
+36
+00:02:35.600 --> 00:02:40.400
+because once you host in S3 and CloudFront, that can scale to a massive amount,
+
+37
+00:02:40.400 --> 00:02:42.000
+still with very little cost.
+
+38
+00:02:42.000 --> 00:02:46.560
+The main frameworks that emerged in the last decade that try to cover this kind of use cases
+
+39
+00:02:46.560 --> 00:02:48.560
+are probably React, Vue, and Angular.
+
+40
+00:02:48.560 --> 00:02:51.520
+There are so many others, and your framework comes out every week.
+
+41
+00:02:51.520 --> 00:02:55.280
+But these are probably the three main ones that you will find in most projects.
+
+42
+00:02:55.280 --> 00:02:59.120
+Now, there are some problems with this approach, this SPA's approach.
+
+43
+00:02:59.120 --> 00:03:03.600
+One problem is that you have perceived loading times that can be very long.
+
+44
+00:03:03.600 --> 00:03:07.920
+And this is because until all the JavaScript is loaded in the page, you basically see an empty page.
+
+45
+00:03:07.920 --> 00:03:12.640
+You see just a white screen, and it might look like the website is broken if it takes too long.
+
+46
+00:03:12.640 --> 00:03:17.040
+And with some framework, it's actually very easy to forget to do some optimization,
+
+47
+00:03:17.040 --> 00:03:20.880
+and you might end up with your JavaScript bundle that can be multiple megabytes.
+
+48
+00:03:20.880 --> 00:03:25.360
+So really, lots of people might have this risk if they underestimate the effort and
+
+49
+00:03:25.360 --> 00:03:28.240
+optimize the JavaScript code that you just deploy your application,
+
+50
+00:03:28.240 --> 00:03:32.240
+you expect everything works perfectly, but then the user has a very bad experience.
+
+51
+00:03:32.240 --> 00:03:35.760
+We also mentioned that all dynamic data needs to be loaded externally.
+
+52
+00:03:35.760 --> 00:03:38.960
+So that means that for all the kind of stuff, you need to build your own API,
+
+53
+00:03:38.960 --> 00:03:44.320
+you need to deploy that API independently, and then your UI still needs to fetch all of that
+
+54
+00:03:44.320 --> 00:03:48.400
+data, which might add to the delay before the user can see something useful.
+
+55
+00:03:48.400 --> 00:03:53.360
+And that also creates some SEO problems because search engines will access your website,
+
+56
+00:03:53.360 --> 00:03:58.320
+but then everything is happening after JavaScript is loaded, and not every search engine will
+
+57
+00:03:58.320 --> 00:04:02.480
+actually wait for that amount of time or even try to run JavaScript.
+
+58
+00:04:02.480 --> 00:04:08.880
+So your indexing against search engines might be not necessarily the best because it's going to be
+
+59
+00:04:08.880 --> 00:04:12.640
+very unpredictable what different engines will be able to see from your website.
+
+60
+00:04:12.640 --> 00:04:17.600
+So to address all these problems in the last few years, this trend of building UIs has evolved a
+
+61
+00:04:17.600 --> 00:04:22.000
+little bit, and it seems like we are going back to server-side rendering. So what we used to do
+
+62
+00:04:22.000 --> 00:04:27.040
+in the times of PHP, Ruby or Rails, Django, basically you always have a server that's
+
+63
+00:04:27.040 --> 00:04:31.920
+generating all the HTML, all the JavaScript, CSS for your websites, and you can generate all of
+
+64
+00:04:31.920 --> 00:04:36.080
+that stuff dynamically. So whenever you need to read data from a database, your server will do
+
+65
+00:04:36.080 --> 00:04:40.000
+that, compile the final page for the user, and then send all the assets to that.
+
+66
+00:04:40.000 --> 00:04:44.800
+So in the JavaScript space, there are some new tools that have emerged to try to satisfy this
+
+67
+00:04:44.800 --> 00:04:50.080
+need, and probably one of the main ones is Next.js. And Next.js basically allows you to do
+
+68
+00:04:50.080 --> 00:04:54.400
+everything still with JavaScript. So you will be able to use, for instance, if you like React,
+
+69
+00:04:54.400 --> 00:04:59.200
+you will be able to use React components both on the client-side and the server-side. And Next.js
+
+70
+00:04:59.200 --> 00:05:04.000
+gives you an experience, a development experience, where it's easy to perform actions on the server
+
+71
+00:05:04.000 --> 00:05:08.320
+and pre-generate content, ship that content directly to the user, so it's going to be loaded
+
+72
+00:05:08.320 --> 00:05:13.040
+very quickly. And then whenever you need to do something client-side, you can still use all the
+
+73
+00:05:13.040 --> 00:05:17.440
+tools that you generally use with React and do client-side stuff. So it's kind of an hybrid,
+
+74
+00:05:17.440 --> 00:05:21.360
+where in the same application, you can define all the backend logic and the frontend logic,
+
+75
+00:05:21.360 --> 00:05:26.560
+and wherever you need to share components, Next.js makes it very easy. Now, Next.js is an open source
+
+76
+00:05:26.560 --> 00:05:30.560
+project that is built and maintained by Vercel. And of course, Vercel has an interest in that
+
+77
+00:05:30.560 --> 00:05:35.360
+project because they have a commercial offering where they make it very, very easy to host Next.js
+
+78
+00:05:35.360 --> 00:05:40.080
+projects and more. And we think that their experience is actually very interesting.
+
+79
+00:05:40.080 --> 00:05:45.200
+So maybe we should talk a little bit more about that, just to see how this tool announced by AWS
+
+80
+00:05:45.200 --> 00:05:49.120
+compares to that kind of experience.
+
+81
+00:05:49.120 --> 00:05:55.120
+The number one thing that you'd think about when you think about Vercel is probably the developer experience. And that involves how easy is it to get up and
+
+82
+00:05:55.120 --> 00:06:00.960
+running and deploy your first application and keep it running. And the zero-config nature of Vercel
+
+83
+00:06:00.960 --> 00:06:04.960
+is probably one of its best selling points because it's just very easy to connect your GitHub repo
+
+84
+00:06:04.960 --> 00:06:10.320
+and have something deployed in a couple of minutes. It doesn't just limit itself to Next.js
+
+85
+00:06:10.320 --> 00:06:14.880
+as well. It supports many other frameworks out of the box. And when you deploy it, you get the
+
+86
+00:06:14.880 --> 00:06:20.480
+automated deployment from your repo, but you also get custom domains and your HTTPS certificates
+
+87
+00:06:20.480 --> 00:06:25.520
+are going to be provisioned for you. And then it'll also scale on demand for you. So it's
+
+88
+00:06:25.520 --> 00:06:29.280
+using other cloud providers under the hood, including AWS, and it's managing all of the
+
+89
+00:06:29.280 --> 00:06:35.040
+scalability. But as well as just scaling within regions on cloud providers, it's also edge
+
+90
+00:06:35.040 --> 00:06:40.240
+optimized. So it's doing edge up deployments as well to various CDNs and running a lot of those
+
+91
+00:06:40.240 --> 00:06:45.280
+server actions and server component rendering on the edge for low latency. One of the really
+
+92
+00:06:45.280 --> 00:06:49.440
+cool things is that if you're working with branches, it will give you preview deployments
+
+93
+00:06:49.440 --> 00:06:53.520
+from your branches. So this means that right away, when you create a feature branch or a fixed branch,
+
+94
+00:06:53.520 --> 00:06:57.360
+and you're working on something, you immediately get a preview URL that you can share with
+
+95
+00:06:57.360 --> 00:07:02.720
+stakeholders. And one of the cool features of that is that your participants can annotate
+
+96
+00:07:02.720 --> 00:07:07.520
+and make comments in line in your preview environment. So you can iterate really quickly
+
+97
+00:07:07.520 --> 00:07:12.560
+with feedback. It also has a whole set of other integrations with other products like databases,
+
+98
+00:07:12.560 --> 00:07:16.320
+you can get a Postgres database up and running pretty quickly. You get logs,
+
+99
+00:07:16.320 --> 00:07:22.480
+they've been putting a lot of investment into AI support recently, CMS integration, and also other
+
+100
+00:07:22.480 --> 00:07:27.680
+things like analytics and important security aspects as well. So there's a whole lot to love
+
+101
+00:07:27.680 --> 00:07:32.480
+about Vercel, but they're not a sponsor of this episode. So while we like the developer experience
+
+102
+00:07:32.480 --> 00:07:36.720
+and the feature set, it's still a software as a service, and you have a build or buy decision,
+
+103
+00:07:36.720 --> 00:07:41.520
+and you have to evaluate the vendor on their own merits. If you want some more control autonomy
+
+104
+00:07:41.520 --> 00:07:46.480
+around the infrastructure, you might want to deploy it to your own AWS account. And Vercel
+
+105
+00:07:46.480 --> 00:07:50.640
+isn't something that will allow you to do that. So if you use Vercel, you don't have a lot of
+
+106
+00:07:50.640 --> 00:07:55.760
+visibility into how your code is deployed and where it's going under the hood. And especially
+
+107
+00:07:55.760 --> 00:08:00.240
+in the context of working with enterprise organizations, there are a lot of good reasons
+
+108
+00:08:00.240 --> 00:08:06.320
+to avoid Vercel and to host front end applications yourself directly on AWS. So where do we start?
+
+109
+00:08:06.320 --> 00:08:10.160
+If we want to host a front end on AWS, this is something that we've talked about a lot. It's a
+
+110
+00:08:10.160 --> 00:08:15.680
+bit of a bugbear of ours, I suppose, just trying to find the right most optimal way to host static
+
+111
+00:08:15.680 --> 00:08:20.160
+websites. We covered it in one of the very first episodes, episode three, how do you deploy a static
+
+112
+00:08:20.160 --> 00:08:25.360
+website on AWS? And then back in episode 80, we were talking specifically about private static
+
+113
+00:08:25.360 --> 00:08:30.320
+websites for enterprises. And there was always, it's always a trade off, no clear winner there.
+
+114
+00:08:30.320 --> 00:08:35.280
+But now AWS has announced a new open source tool to help you tackle this problem. And this is the
+
+115
+00:08:35.280 --> 00:08:40.000
+CloudFront hosting toolkit. So this certainly got a lot of people's attention, a lot of people
+
+116
+00:08:40.000 --> 00:08:45.040
+talking because just you only have to mention Vercel competitor to get people's ears pricked
+
+117
+00:08:45.040 --> 00:08:51.520
+up. And Luciano, you've been good enough to take a good look at this for us. So maybe your best
+
+118
+00:08:51.520 --> 00:08:57.040
+place to give us an introduction, what is this CloudFront hosting toolkit and what can we do
+
+119
+00:08:57.040 --> 00:09:01.040
+with it?
+
+120
+00:09:01.040 --> 00:09:06.560
+Yeah, if you look at the announcement blog post, we will have a link in the show notes, they describe this tool as an open source command line interface to help you deploy fast and secure
+
+121
+00:09:06.560 --> 00:09:11.440
+front ends in the cloud. So that kind of tells you what is the ambition of the tool. And the idea is
+
+122
+00:09:11.440 --> 00:09:15.040
+to try to remove as much as possible the complexity of setting up everything you need
+
+123
+00:09:15.040 --> 00:09:21.280
+to run your own front end on AWS. So you have a CLI, you run the CLI, it can, once you install it
+
+124
+00:09:21.280 --> 00:09:24.640
+and run it against your particular repository where you are building your own front end,
+
+125
+00:09:24.640 --> 00:09:29.600
+it can detect the framework of choice. For instance, Next.js is one of the supported ones.
+
+126
+00:09:29.600 --> 00:09:33.520
+And at that point, it can start to generate configuration for you, for instance, recognizing
+
+127
+00:09:33.520 --> 00:09:38.720
+how do you build for this particular front end. It integrates with your repository. Right now,
+
+128
+00:09:38.720 --> 00:09:44.000
+it supports GitHub. And basically what it does, the CLI will allow you to connect your GitHub
+
+129
+00:09:44.000 --> 00:09:48.560
+with a build pipeline hosted in AWS. And also at that point, it can create all the necessary
+
+130
+00:09:48.560 --> 00:09:53.360
+resources. So for instance, what do you need to host a front end? You would need an S3 bucket,
+
+131
+00:09:53.360 --> 00:09:58.000
+you would need the CloudFront distribution, DNS record, TLS certificates, and more. It will create
+
+132
+00:09:58.000 --> 00:10:02.160
+all of that stuff for you using infrastructure as code. So you don't really need to worry about
+
+133
+00:10:02.160 --> 00:10:06.560
+basically coding all these things or figuring out where to find all of the examples to put all these
+
+134
+00:10:06.560 --> 00:10:10.880
+things together. So that removes a lot of the friction of self-hosting your own front ends.
+
+135
+00:10:10.880 --> 00:10:15.440
+And everything that it does, as I said, is done through infrastructure as code, and it's made very
+
+136
+00:10:15.440 --> 00:10:19.760
+accessible. It's still deploying through CloudFormation so you can see exactly what's
+
+137
+00:10:19.760 --> 00:10:24.080
+being deployed. You have configuration files that gets generated for you. So you have also
+
+138
+00:10:24.080 --> 00:10:28.880
+opportunities to still sticking with the same process that is given to you by the CLI. You can
+
+139
+00:10:28.880 --> 00:10:33.200
+tweak and configure certain things to your liking. And then even if at the end of the day, you still
+
+140
+00:10:33.200 --> 00:10:36.960
+want to change more, all the infrastructure is there, all the CloudFormation is there.
+
+141
+00:10:36.960 --> 00:10:41.600
+So you can take that and do further customization if you need to. And somewhere else, I think in the
+
+142
+00:10:41.600 --> 00:10:47.200
+repository, they say something that to me represents the ambition of this project. And it reads us,
+
+143
+00:10:47.200 --> 00:10:51.760
+gives you the convenience of a managed service while putting you in full control of the hosting
+
+144
+00:10:51.760 --> 00:10:57.040
+infrastructure and deployment pipelines to make it your own. So that's a good marketing phrase to
+
+145
+00:10:57.040 --> 00:11:01.360
+say, yes, we want to make it easy for you, but at the end of the day, this is your own infrastructure.
+
+146
+00:11:01.760 --> 00:11:04.480
+You'll have access to it and you'll be able to change everything you need.
+
+147
+00:11:04.480 --> 00:11:06.400
+You can have your cake and eat it.
+
+148
+00:11:06.400 --> 00:11:11.120
+Something like that, yes. But now we get to the more painful notes, I guess, because yeah,
+
+149
+00:11:11.120 --> 00:11:16.720
+just to be real, we need to say that the current state is still a version 1.0 and it's still very,
+
+150
+00:11:16.720 --> 00:11:21.600
+very early. Well, it was announced only a few weeks ago and it's fair to say that it's still
+
+151
+00:11:21.600 --> 00:11:26.000
+very early days. So if our feedback is going to look a little bit harsh in some parts,
+
+152
+00:11:26.000 --> 00:11:30.080
+at the same time, you have to think that this is an evolving project. It's only early stages,
+
+153
+00:11:30.080 --> 00:11:34.800
+so it can only get better. So let's be fair in that sense. So if you look at the supported
+
+154
+00:11:34.800 --> 00:11:40.400
+feature, right now it supports everything that you need to host an SPA that is statically generated.
+
+155
+00:11:40.400 --> 00:11:44.880
+And that is a very important note because it means that right now you cannot do any server
+
+156
+00:11:44.880 --> 00:11:48.960
+side rendering. By default, it doesn't support any of that. So in a way, it's still a little
+
+157
+00:11:48.960 --> 00:11:54.480
+bit behind the current trends. And if you use, for instance, Next.js, Next.js allows you to do
+
+158
+00:11:54.480 --> 00:12:00.640
+websites that are only static generated with some tweaking in the configuration and just by not
+
+159
+00:12:00.640 --> 00:12:05.360
+using certain specific features, you can do that. But you need to be aware that this is an existing
+
+160
+00:12:05.360 --> 00:12:09.440
+limitation. If you want to use this tool with Next.js, you can only use the features that are
+
+161
+00:12:09.440 --> 00:12:15.840
+supported with the pre-rendered static version of the website. The other feature is that, as we said,
+
+162
+00:12:15.840 --> 00:12:20.720
+integrates really well with GitHub for version control. It's going to do for you atomic and
+
+163
+00:12:20.720 --> 00:12:25.840
+immutable Eastern deploys on CloudFront. We'll talk a little bit more about that later. It's a
+
+164
+00:12:25.840 --> 00:12:30.160
+pretty cool implementation. So I think it's worth spending some time on how all of that works.
+
+165
+00:12:30.160 --> 00:12:36.080
+It's a CLI tool, so very easy to install with NPM, very easy to run it in any new project. It takes
+
+166
+00:12:36.080 --> 00:12:40.880
+literally a few seconds just to get started. And also it does security and caching best practices.
+
+167
+00:12:40.880 --> 00:12:44.880
+So all of these things are already incorporated in the generated infrastructure. So one less
+
+168
+00:12:44.880 --> 00:12:49.120
+thing to worry about because if you were doing all of this yourself, maybe you get something working
+
+169
+00:12:49.120 --> 00:12:53.840
+after a few hours of investigation and trainings, but then at the end of the day, you might still be
+
+170
+00:12:53.840 --> 00:12:57.840
+unsure on whether that's something that can be production ready or not. This tool removes a
+
+171
+00:12:57.840 --> 00:13:02.160
+little bit of that concern because it's already following tons of best practices that have been
+
+172
+00:13:02.160 --> 00:13:06.800
+established in the AWS landscape for the last few years. And then it allows you to use custom
+
+173
+00:13:06.800 --> 00:13:12.640
+domains. So if you want to host your own front end in your own custom domain, all of that process
+
+174
+00:13:12.640 --> 00:13:18.080
+is streamlined. It's going to integrate with Route 53 and generate the necessary records,
+
+175
+00:13:18.080 --> 00:13:22.880
+generate the TLS certificates for you, and make sure everything is integrated properly. If you
+
+176
+00:13:22.880 --> 00:13:27.120
+don't have a custom domain, it's going to use a CloudFront domain for you. And finally, there is
+
+177
+00:13:27.120 --> 00:13:32.640
+also a CDK level three construct for the toolkit that can be used as an alternative for the CLI.
+
+178
+00:13:32.640 --> 00:13:37.120
+So that's maybe another option if you prefer to go more with something that is integrated with your
+
+179
+00:13:37.120 --> 00:13:42.960
+own CDK rather than using the CLI. But I mentioned atomic and immutable instant deploys, which is a
+
+180
+00:13:42.960 --> 00:13:47.360
+little bit of a mouthful. So do we want to try to explain what that really is and how it is
+
+181
+00:13:47.360 --> 00:13:52.560
+implemented? Yeah, it's pretty neat.
+
+182
+00:13:52.560 --> 00:13:57.520
+It uses CloudFront functions and CloudFront key value store, which you may not have come across. Let's go through these fundamental pieces of CloudFront
+
+183
+00:13:57.520 --> 00:14:03.120
+first. So CloudFront functions are a little bit like CloudFlare workers, I guess, or other edge
+
+184
+00:14:03.120 --> 00:14:07.520
+functions that you might've come across. They're like a much simpler version of Lambda because you
+
+185
+00:14:07.520 --> 00:14:13.120
+also have Lambda at the edge, but Lambda at the edge is more like a fully fledged Lambda,
+
+186
+00:14:13.120 --> 00:14:18.960
+although not quite. CloudFront functions are just more like lightweight JavaScript isolated
+
+187
+00:14:18.960 --> 00:14:24.960
+contexts that are much more efficient, but also restricted in terms of what packages you can use
+
+188
+00:14:24.960 --> 00:14:29.840
+and that sort of thing. So you could use CloudFront functions for writing lightweight functions for
+
+189
+00:14:30.400 --> 00:14:37.920
+high-scale latency-sensitive CDN customizations like redirects or request response modification,
+
+190
+00:14:38.400 --> 00:14:43.600
+URL rewrites, that sort of thing. And then you have CloudFront key value store. And this is a
+
+191
+00:14:43.600 --> 00:14:48.800
+bit like a simplified version of DynamoDB that runs on the edge. And we've seen this kind of
+
+192
+00:14:48.800 --> 00:14:56.000
+service from CloudFront, sorry, from CloudFlare as well. It's a global low latency key value store,
+
+193
+00:14:56.000 --> 00:15:01.760
+and it allows you to read from CloudFront functions. And by having that state in your
+
+194
+00:15:01.760 --> 00:15:07.280
+key value store, you can do more customizable logic at the edge functions. So when you have
+
+195
+00:15:07.360 --> 00:15:13.200
+CloudFront key value store, you can make updates to function code and updates to the data associated
+
+196
+00:15:13.200 --> 00:15:18.160
+with the function independently of each other. This kind of separation will simplify your
+
+197
+00:15:18.160 --> 00:15:22.160
+functions code and makes it easy to update data without the need to deploy code changes.
+
+198
+00:15:23.040 --> 00:15:27.520
+Now, when it comes back to this CloudFront hosting toolkit, the basic idea is that every time you
+
+199
+00:15:27.520 --> 00:15:32.800
+want to deploy a new version of your front end, rather than replacing the entire content of the
+
+200
+00:15:32.800 --> 00:15:38.000
+S3 bucket hosting your assets or overwriting, you'll create a new unique deployment ID and
+
+201
+00:15:38.000 --> 00:15:43.120
+host all the files for a deployment version in a dedicated prefix, like a subfolder. So let's say
+
+202
+00:15:43.120 --> 00:15:47.280
+your first deployment ID is version one, then it'll create a prefix like slash version one.
+
+203
+00:15:47.280 --> 00:15:53.840
+And then within that, you'll have your index.html and your bundled JavaScript. And then with your
+
+204
+00:15:53.840 --> 00:15:58.240
+second deployment, it would be version two under a slash version two prefix. So when a user will
+
+205
+00:15:58.240 --> 00:16:05.600
+try to access a page by doing get index.html, this request goes to CloudFront first and the
+
+206
+00:16:05.600 --> 00:16:10.320
+CloudFront function is the first bit of logic that gets evaluated. It can go to the CloudFront
+
+207
+00:16:10.320 --> 00:16:14.480
+key value store to read the ID of the latest deployed version. And the function will then
+
+208
+00:16:14.480 --> 00:16:20.080
+rewrite the URL to point to the specific assets in the S3 origin for that current version.
+
+209
+00:16:20.080 --> 00:16:25.840
+So if you're going, making a request to get slash about that would become get slash version two
+
+210
+00:16:26.160 --> 00:16:31.680
+slash about dot html, for example. So then it'll load that specific asset from S3 or cache and
+
+211
+00:16:31.680 --> 00:16:35.440
+return it to the user. And then when you have a new deployment, it'll just create a new prefix
+
+212
+00:16:35.440 --> 00:16:40.000
+in S3 to host all those assets. When all is done, the new version ID is stored in that key value
+
+213
+00:16:40.000 --> 00:16:43.840
+store. And the next time somebody is accessing the website, they'll get the latest version. Now,
+
+214
+00:16:43.840 --> 00:16:47.920
+there's a few nice things about this approach. It's an immutable deployment approach, which means
+
+215
+00:16:47.920 --> 00:16:52.880
+that every deployment is clean and new, and you can troubleshoot it in its own space. But you also
+
+216
+00:16:52.960 --> 00:16:57.920
+retain older versions, which would make it easy to do rollbacks if you have to do that. There is
+
+217
+00:16:57.920 --> 00:17:01.840
+little risk then that a user will receive assets from different versions, which is a common problem
+
+218
+00:17:01.840 --> 00:17:07.440
+if you're just kind of overwriting into a single prefix in S3 or if they're accessing the website
+
+219
+00:17:07.440 --> 00:17:13.120
+during an update. The other nice thing about this is that it could easily support preview
+
+220
+00:17:13.120 --> 00:17:17.440
+environments. But we haven't seen anything showing that this is supported yet in CloudFront hosting
+
+221
+00:17:17.440 --> 00:17:22.560
+toolkit, but it seems like this kind of architecture would certainly enable it. So
+
+222
+00:17:22.560 --> 00:17:27.920
+maybe let's talk about your real world practice. You've taken it for a good test drive CloudFront
+
+223
+00:17:27.920 --> 00:17:32.160
+hosting toolkit, and you've had some successes and some bumps in the road Luciano.
+
+224
+00:17:34.800 --> 00:17:41.520
+So I'm going to try to describe the steps that I performed to try to test this tool and the different things that I found out.
+
+225
+00:17:41.520 --> 00:17:45.680
+And hopefully that can give you an idea of how the tool works, the kind of developer experience
+
+226
+00:17:45.760 --> 00:17:51.200
+you get and what gets created for you behind the scenes. So I started with a plain vanilla Next.js
+
+227
+00:17:51.200 --> 00:17:56.960
+project. There is one CLI command that you can find in the Next.js documentation that basically
+
+228
+00:17:56.960 --> 00:18:02.960
+uses a starter kit. And that starter kit is just a simple repo where you have a one Next.js page
+
+229
+00:18:02.960 --> 00:18:08.560
+that points you to the documentation, to the about page and a few other simple things. So effectively
+
+230
+00:18:08.560 --> 00:18:13.520
+it's like one page application, and it's like a static, statically renderable application because
+
+231
+00:18:13.520 --> 00:18:18.000
+it doesn't really do any server side action or anything like that. So you run this first command,
+
+232
+00:18:18.000 --> 00:18:22.720
+this command will do all the scaffolding for you. At that point, you can do npm install to install
+
+233
+00:18:22.720 --> 00:18:27.360
+the dependencies. And if you want to run your frontend locally, just to see it running and play
+
+234
+00:18:27.360 --> 00:18:32.640
+around with it, you can just say npm run dev, and that will give you locally an environment that you
+
+235
+00:18:32.640 --> 00:18:36.880
+can use to tweak things around. Then at some point you are maybe happy with it and you want to try to
+
+236
+00:18:36.880 --> 00:18:41.440
+deploy it using this CloudFront hosting toolkit. The first thing you need to do is install the
+
+237
+00:18:41.440 --> 00:18:46.640
+toolkit itself. We said it's a CLN application, it's built with Node.js. So of course Node.js
+
+238
+00:18:46.640 --> 00:18:52.800
+becomes a requirement at that point. But once you do that, you can easily install with MPX or just
+
+239
+00:18:52.800 --> 00:18:59.600
+by doing an npm install global of the art AWS slash CloudFront dash hosting dash toolkit. And
+
+240
+00:18:59.600 --> 00:19:04.240
+that will basically pull the latest version of the toolkit for you in your local development
+
+241
+00:19:04.240 --> 00:19:08.160
+environment. Now the idea is that you need to use it against an existing repository. So this is why
+
+242
+00:19:08.160 --> 00:19:14.000
+I created an XJS project first. Once I did all of that and I was happy with the outcome, then you
+
+243
+00:19:14.000 --> 00:19:19.760
+can start the tool. And the way you start the tool, you go with your CLI into the specific folder where
+
+244
+00:19:19.760 --> 00:19:24.880
+you have your frontend application and you just run CloudFront dash hosting dash toolkit space
+
+245
+00:19:24.880 --> 00:19:30.160
+init. That's literally the one command you need to run. And at that point, you have a guided process
+
+246
+00:19:30.160 --> 00:19:35.120
+that will effectively ask you some questions to try to understand how to deploy this project for
+
+247
+00:19:35.120 --> 00:19:39.280
+you. And the first question that it's going to ask is what is your repository? And of course,
+
+248
+00:19:39.280 --> 00:19:44.480
+it's going to be able to auto detect it from the current working folder. If you have already
+
+249
+00:19:44.480 --> 00:19:48.800
+initialized that as a Git repository and it's hosted on GitHub, it's going to automatically
+
+250
+00:19:48.800 --> 00:19:52.880
+complete that particular question. But you can change it if you have different requirements,
+
+251
+00:19:52.880 --> 00:19:57.440
+or maybe if you haven't set up the repo yet locally, you can still point it to a repo that
+
+252
+00:19:57.440 --> 00:20:02.160
+you have set up already remotely on GitHub. The next step is going to ask you the name of the
+
+253
+00:20:02.160 --> 00:20:07.840
+branch for deployments. It defaults to main, but I think you can use this if you want to change that
+
+254
+00:20:07.840 --> 00:20:12.560
+to something else. Maybe you want to have a branch called deployment or deploy that you specifically,
+
+255
+00:20:12.560 --> 00:20:16.400
+when you want to trigger a deploy, you can decide which branch is actually going to trigger the
+
+256
+00:20:16.400 --> 00:20:21.440
+deployments that way. The next question is what is your framework of choice? And here, you have a few
+
+257
+00:20:21.440 --> 00:20:27.200
+frameworks that are supported. AngularJS, Next.js, React, Vue.js. There is another one which is
+
+258
+00:20:27.200 --> 00:20:31.680
+no build required, which basically means everything that is in the main folder is going to
+
+259
+00:20:31.680 --> 00:20:37.040
+be deployed. And I think this is for static websites that don't require a build process. Maybe
+
+260
+00:20:37.040 --> 00:20:41.840
+you just created a few simple HTML, CSS, and JavaScript files. You have them there and you just
+
+261
+00:20:41.840 --> 00:20:46.080
+want to deploy them. The cool thing here is that it was able to automatically detect that I was
+
+262
+00:20:46.080 --> 00:20:51.680
+using Next.js. So that option was already selected for me. I just needed to hit enter and proceed.
+
+263
+00:20:51.680 --> 00:20:56.640
+But of course, you can change that if maybe it's not able to detect your framework, or maybe you
+
+264
+00:20:56.640 --> 00:21:00.960
+are actually using something else and it didn't really detect it correctly. The next step is
+
+265
+00:21:01.600 --> 00:21:07.200
+asking you if you want to use a specific domain name, or if you want to use the default CloudFront
+
+266
+00:21:07.200 --> 00:21:11.920
+domains. In this particular case, I didn't have a domain, so I just went with the CloudFront one,
+
+267
+00:21:11.920 --> 00:21:16.400
+which maybe is a little bit of a simpler path. I'd be curious to try it again with a custom domain,
+
+268
+00:21:16.400 --> 00:21:21.120
+just to see all the extra resources that it needs to create to support that. But I haven't done that
+
+269
+00:21:21.120 --> 00:21:25.280
+yet. Once you've done all of this, this is basically the initial setup. So it's basically
+
+270
+00:21:25.280 --> 00:21:30.240
+making sure that it understands your project and the configuration of your project. But at that
+
+271
+00:21:30.240 --> 00:21:34.160
+point, it can start to generate things for you. And it's interesting to see that it generates a
+
+272
+00:21:34.160 --> 00:21:39.440
+folder called the CloudFront-hosting-toolkit. And in this folder, it will generate three files for
+
+273
+00:21:39.440 --> 00:21:44.160
+you. The first file is a code build job configuration. So it's basically the YAML file
+
+274
+00:21:44.160 --> 00:21:48.320
+that contains all of that configuration. And this is awesome because that means that if you want to
+
+275
+00:21:48.320 --> 00:21:52.800
+change anything in the pre-generated build step, because it's kind of assuming, okay, this is a
+
+276
+00:21:52.800 --> 00:21:57.920
+Next.js project. I know how to build a Next.js project, but maybe you have additional requirements.
+
+277
+00:21:57.920 --> 00:22:02.000
+Maybe you want to do additional things that are not the standard way of building an Next.js website.
+
+278
+00:22:02.000 --> 00:22:07.280
+You can easily change all the steps and customize it to your liking without having to change the
+
+279
+00:22:07.280 --> 00:22:11.760
+toolkit or having to change anything else in the infrastructure as code. So it's just this one file
+
+280
+00:22:11.760 --> 00:22:16.560
+allows you to change things. It also generates in this folder the CloudFront function that is used
+
+281
+00:22:16.560 --> 00:22:21.840
+for URL rewriting, the one you described before, Eoin. And you can see all the JavaScript code that
+
+282
+00:22:21.840 --> 00:22:26.640
+is being generated. So also there, you have an opportunity to change things around. Maybe you can,
+
+283
+00:22:26.640 --> 00:22:31.040
+I don't know, add some extra logic to check if there is a query string parameter that says
+
+284
+00:22:31.040 --> 00:22:36.000
+version equals something. Maybe you can actually enable that feature preview that way and by
+
+285
+00:22:36.000 --> 00:22:39.600
+yourself, assuming that it's not supported yet. But basically, this is just to tell you that you
+
+286
+00:22:39.600 --> 00:22:43.840
+have one file with all the logic that are visible. It's easy to change. And if you change it, this is
+
+287
+00:22:43.840 --> 00:22:48.560
+what's going to get deployed for you. And then finally, there is a generic JSON file that contains
+
+288
+00:22:48.560 --> 00:22:54.240
+all the options that were requested to you in the initial init phase. So if you change your mind,
+
+289
+00:22:54.240 --> 00:22:58.000
+maybe you don't want to deploy from main anymore, you want to deploy from another branch, you can
+
+290
+00:22:58.000 --> 00:23:02.880
+easily change that JSON file to get your base configuration updated. At that point, what you
+
+291
+00:23:02.880 --> 00:23:09.200
+can do is that you can effectively deploy. At this point, you haven't deployed anything. You just
+
+292
+00:23:09.200 --> 00:23:13.360
+generated these three configuration files, but those three configuration files are enough for
+
+293
+00:23:13.360 --> 00:23:18.080
+you to start the deployment. So you can run another command called cloudfront-osting-toolkit
+
+294
+00:23:18.080 --> 00:23:22.000
+space deploy. And what it's going to do is basically going to take all these three generated
+
+295
+00:23:22.000 --> 00:23:27.040
+files as an input, and it's going to create all the necessary cloud formation templates to deploy
+
+296
+00:23:27.040 --> 00:23:31.760
+everything else that we described before. So it's three buckets, cloud front, the distributions,
+
+297
+00:23:31.760 --> 00:23:36.480
+the cloud front function, the cloud front key value storage, and there is a lot more. You can
+
+298
+00:23:36.480 --> 00:23:41.200
+check out, there is a diagram in the announcement page and in the repository showing exactly all the
+
+299
+00:23:41.200 --> 00:23:45.280
+resources that get created and how they are related to each other. And this is also going
+
+300
+00:23:45.280 --> 00:23:49.840
+to do a few other things. So initially it's going to bootstrap your AWS account, which I think it
+
+301
+00:23:49.840 --> 00:23:54.320
+means it's going to create a dedicated street bucket for the deployments. It's going to create
+
+302
+00:23:54.320 --> 00:23:58.480
+the repository, the CodeStar integration. And actually the CodeStar integration is really
+
+303
+00:23:58.480 --> 00:24:02.960
+interesting because what it does the first time you need to manually confirm that connection
+
+304
+00:24:02.960 --> 00:24:07.600
+between your GitHub account and AWS. And it's something that you have to do in a browser where
+
+305
+00:24:07.600 --> 00:24:12.160
+you are effectively authenticated on both sides. So what it's going to do is going to generate
+
+306
+00:24:12.160 --> 00:24:16.800
+the request for you. Then it's going to redirect you to the AWS console and in the AWS console,
+
+307
+00:24:16.800 --> 00:24:21.760
+you can click to basically connect your own GitHub account. To be honest, this was amazing to see on
+
+308
+00:24:21.760 --> 00:24:25.680
+one side, but on the other side, in my case, it was a little bit annoying because I use,
+
+309
+00:24:25.680 --> 00:24:30.480
+when I access to AWS, I generally use anonymous sessions because I might have sessions for
+
+310
+00:24:30.480 --> 00:24:34.320
+different AWS accounts. So when I was trying to connect to GitHub, it didn't have my own
+
+311
+00:24:34.400 --> 00:24:39.840
+credentials. And it took me a while to connect into that anonymous environment with GitHub,
+
+312
+00:24:39.840 --> 00:24:45.360
+asking you MFA and confirmation by email, just because they see that it's a different session
+
+313
+00:24:45.360 --> 00:24:49.920
+that you haven't used before. But eventually I managed to get it working. And then all the
+
+314
+00:24:49.920 --> 00:24:56.240
+local setup was done. The remote setup was done on AWS. And you just need to click enter to say
+
+315
+00:24:56.240 --> 00:25:01.920
+that you successfully connected GitHub with AWS. And then at that point it's going to proceed with
+
+316
+00:25:01.920 --> 00:25:06.800
+the cloud formation deployment. Now, at this point, I had a problem because once everything
+
+317
+00:25:06.800 --> 00:25:11.920
+is deployed for you, it's also going to try to run the code build for the first time and try to do a
+
+318
+00:25:11.920 --> 00:25:16.000
+first deployment of your front-end application. Like if you were doing your first commit,
+
+319
+00:25:16.000 --> 00:25:21.440
+basically. And that one actually failed because there is an issue with the version of Next.js
+
+320
+00:25:21.440 --> 00:25:26.480
+that I'm using. I'm using the very latest version and that latest version doesn't support Next
+
+321
+00:25:26.480 --> 00:25:32.400
+export, which is what the default build pipeline is using to create the static version of the
+
+322
+00:25:32.400 --> 00:25:37.360
+website. Now, this is something you can easily fix. You just need to create a Next config.js file,
+
+323
+00:25:37.360 --> 00:25:41.520
+do the modern way of saying that you want to produce a static website, which is just like
+
+324
+00:25:41.520 --> 00:25:45.840
+one option, I think it's export static or something like that. Commit that into your own
+
+325
+00:25:45.840 --> 00:25:51.040
+repository. And of course you also need to update the code build pipeline, not to use Next export
+
+326
+00:25:51.040 --> 00:25:55.680
+anymore, because at that point, when you do Next build, it's already creating the final version of
+
+327
+00:25:55.680 --> 00:25:59.920
+your website for deployment. And this is basically where I stopped, but I could see that everything
+
+328
+00:25:59.920 --> 00:26:04.320
+was generated correctly. I could see that if I was doing another commit, the build pipeline would
+
+329
+00:26:04.320 --> 00:26:08.960
+trigger automatically and do all of the deployment we described. So I think even though there are
+
+330
+00:26:08.960 --> 00:26:13.680
+some steps that might be a little bit annoying, overall, that experience was quite pleasant.
+
+331
+00:26:13.680 --> 00:26:18.080
+I don't know what you think so far, and if you have any final consideration on your end.
+
+332
+00:26:18.160 --> 00:26:22.880
+You know, we talked about this kind of stuff when we were talking about CDK in previous episodes.
+
+333
+00:26:22.880 --> 00:26:28.880
+I personally have a bias against code, sorry, against tools that generate code that introduce
+
+334
+00:26:28.880 --> 00:26:33.120
+another level of abstraction, mainly because it's just another, you have to understand kind of
+
+335
+00:26:33.120 --> 00:26:37.600
+what's going on under the hood, and then also what's happening in this abstraction layer. And
+
+336
+00:26:37.600 --> 00:26:41.280
+if, especially with a tool like this that might not be perfectly stable yet, you might wonder,
+
+337
+00:26:41.280 --> 00:26:46.000
+will it suddenly generate a completely different set of infrastructure that might make it difficult
+
+338
+00:26:46.000 --> 00:26:51.200
+to do seamless upgrades? And I'd much prefer to spend the time to provision all of the
+
+339
+00:26:51.200 --> 00:26:56.720
+infrastructure myself and really understand it more often than not. But I can certainly see
+
+340
+00:26:56.720 --> 00:27:01.280
+the value in it, because I have been in a case recently where I've been trying to deploy a static
+
+341
+00:27:01.280 --> 00:27:06.400
+version, like a SPA version of an XJS app, with only client-side rendering, with static export
+
+342
+00:27:06.400 --> 00:27:11.920
+to CloudFront, and it's definitely not a trivial thing. So I think there's, I definitely commend
+
+343
+00:27:11.920 --> 00:27:17.520
+the effort here to get all of this stuff working. It's not an easy thing to do, and it does provide
+
+344
+00:27:17.520 --> 00:27:23.200
+like a good blueprint for people to get started with it. So while my bias isn't necessarily drawn
+
+345
+00:27:23.200 --> 00:27:28.240
+to a tool like this, I think it is pretty promising. I think there's some really good
+
+346
+00:27:28.240 --> 00:27:32.160
+ideas in here, like the immutable deployments, and it seems to be simple enough to use. There's
+
+347
+00:27:32.160 --> 00:27:36.000
+obviously some rough edges that need to be polished. The fact that it doesn't support
+
+348
+00:27:36.000 --> 00:27:40.080
+server-side rendering may be a bit of a blocker for a lot of people at this point. Let's hope
+
+349
+00:27:40.080 --> 00:27:46.080
+we'll see a bit of evolution there. I mean, I kind of think back to one of the previous
+
+350
+00:27:46.080 --> 00:27:50.880
+releases from AWS we covered, which was the integration testing toolkit, the IITK,
+
+351
+00:27:50.880 --> 00:27:55.840
+and it was also a similar kind of review, like a lot of promising stuff, but needs more work.
+
+352
+00:27:55.840 --> 00:28:00.160
+And when I went back to look at that recently, because I did use it in a side project,
+
+353
+00:28:01.040 --> 00:28:06.640
+it doesn't seem to have actually evolved that much. So I know, we know that AWS likes to
+
+354
+00:28:06.640 --> 00:28:11.120
+release things early and get feedback from the user base, but let's hope that this one
+
+355
+00:28:11.120 --> 00:28:14.480
+sees the love and attention that we need. What's your take?
+
+356
+00:28:14.480 --> 00:28:18.800
+Yeah, I absolutely agree with everything you said.
+
+357
+00:28:18.800 --> 00:28:24.880
+A few things that I can mention in addition to that is that I was able to fix an initial issue that I had with the CLI not
+
+358
+00:28:24.880 --> 00:28:30.480
+installing properly. So I just submitted a PR and I was impressed to see how quickly I got a review.
+
+359
+00:28:30.480 --> 00:28:37.200
+The PR was properly commented and released and very quickly all happened in the span of an hour.
+
+360
+00:28:37.200 --> 00:28:42.000
+And the problem was fixed immediately. The maintainer was extremely welcoming. So that's
+
+361
+00:28:42.000 --> 00:28:46.960
+definitely a good thing to see. And I think that creates a big opportunity for everyone that wants
+
+362
+00:28:46.960 --> 00:28:51.520
+to contribute to this kind of project to be able to do that. It seems really like a very welcoming
+
+363
+00:28:51.520 --> 00:28:56.080
+environment for people to contribute. So maybe if the tool doesn't have all the things you need
+
+364
+00:28:56.080 --> 00:29:00.160
+and you are willing to invest a little bit on it, definitely think about contributing and
+
+365
+00:29:00.160 --> 00:29:04.160
+giving back and working with the maintainer to get to the point where this tool is actually
+
+366
+00:29:04.160 --> 00:29:09.440
+going to be helpful for you and for other people. So that's absolutely a plus one for the tool and
+
+367
+00:29:09.440 --> 00:29:14.480
+the current maintaining team. Another thing that I think is worth mentioning is that there is another
+
+368
+00:29:14.480 --> 00:29:19.200
+walkthrough by our friend Sandro Volpicella. We will have the link in the show notes. He has also
+
+369
+00:29:19.200 --> 00:29:24.080
+done a similar kind of test ride of the tool and wrote a blog post detailing all the things that
+
+370
+00:29:24.080 --> 00:29:28.080
+he found out. I think there is even a few more things that he explains. Like for instance,
+
+371
+00:29:28.080 --> 00:29:31.920
+there is a step function that is used for updating the versions and he also goes through on
+
+372
+00:29:31.920 --> 00:29:36.240
+how that works and why it needs to be there and maybe how it can be improved. So if you want to
+
+373
+00:29:36.240 --> 00:29:40.160
+do an additional deep dive on the technology and get another perspective on the tool,
+
+374
+00:29:40.160 --> 00:29:44.400
+definitely recommend to read that blog post. And then finally, I think it's worth mentioning a
+
+375
+00:29:44.400 --> 00:29:48.800
+few potential alternatives because we are effectively working with a customer that might
+
+376
+00:29:48.800 --> 00:29:53.120
+need this kind of stuff. So we are doing lots of research on what are the possible options there.
+
+377
+00:29:53.120 --> 00:29:57.280
+And it's also a topic we are really passionate about. As you can see, we keep talking about this.
+
+378
+00:29:58.080 --> 00:30:02.160
+So other things that we think are going to be suitable, for instance, you can more or less
+
+379
+00:30:02.160 --> 00:30:06.640
+relatively easy, you should be able to create a container and then run that container with a Next
+
+380
+00:30:06.640 --> 00:30:11.440
+JS application with full server-side rendering either on a Prunner or Fargate. But then of course,
+
+381
+00:30:11.440 --> 00:30:15.520
+you have something that is running 24 seven. So maybe not necessarily what you want to do if you
+
+382
+00:30:15.520 --> 00:30:19.680
+want a more serverless approach. And in that front, there is another project that seems very
+
+383
+00:30:19.680 --> 00:30:25.120
+promising that is called OpenNext, which we haven't tried yet, but in the docs, it says that it also
+
+384
+00:30:25.120 --> 00:30:30.720
+supports server-side rendering on Lambda. So that seems maybe a closer re-implementation of what
+
+385
+00:30:30.720 --> 00:30:35.520
+Vercel does for you, but that you can deploy on your own on AWS. It's definitely worth a look.
+
+386
+00:30:35.520 --> 00:30:40.160
+And hopefully we will have time to try it out and maybe give you an overview of what that looks like.
+
+387
+00:30:40.160 --> 00:30:44.320
+Similarly, there is another project called Coolify, which is a little bit more generic.
+
+388
+00:30:44.960 --> 00:30:50.640
+It's probably a modern take on Heroku. So it allows you to host your own bus and it does that
+
+389
+00:30:50.640 --> 00:30:56.240
+in a serverless way. But as such, you should be able to host a container that you can run with
+
+390
+00:30:56.240 --> 00:31:00.560
+everything you need to run an Next JS project. So another thing that we really like to try,
+
+391
+00:31:00.560 --> 00:31:05.200
+we haven't had the time yet, but if we do try it, we'll let you know our findings. And finally,
+
+392
+00:31:05.200 --> 00:31:10.240
+there is Amplify, which always gets mentioned every time that people talk about Vercel versus
+
+393
+00:31:10.240 --> 00:31:14.880
+AWS. I don't personally have an opinion on that one because I haven't really used Amplify much.
+
+394
+00:31:14.880 --> 00:31:18.560
+So, oh, and I'll leave it to you to mention something about Amplify if you want.
+
+395
+00:31:18.640 --> 00:31:21.840
+I've looked at, you know, I don't have a huge amount of experience either.
+
+396
+00:31:21.840 --> 00:31:27.920
+I've used the Amplify CLI and the client SDK a lot. The managed side of Amplify is a whole other set of features.
+
+397
+00:31:27.920 --> 00:31:34.720
+Like they allow you to easily provision storage and hosting and all sorts of other stuff. I know
+
+398
+00:31:34.720 --> 00:31:40.320
+that they've introduced a new generation two, and I'd love to do an episode on that in the future.
+
+399
+00:31:40.880 --> 00:31:45.520
+But from what I can see with the new generation two Amplify, it's also solving the same sort of
+
+400
+00:31:45.520 --> 00:31:50.560
+problem in a much more managed service kind of way. So it seems a little bit more like an AWS
+
+401
+00:31:50.560 --> 00:31:56.960
+managed Vercel alternative. And I think from what I've seen so far, a lot of work has gone into
+
+402
+00:31:56.960 --> 00:32:00.480
+that. I haven't tried it, so I don't know exactly what the experience is like. Let us know if you
+
+403
+00:32:00.480 --> 00:32:06.240
+have, because I'd love to know. I have seen some online discussion. Actually Yan Shui was
+
+404
+00:32:07.200 --> 00:32:13.040
+mentioning the release of the CloudFront hosting toolkit. And one of the principal essays at AWS
+
+405
+00:32:13.040 --> 00:32:16.800
+was answering the question, well, why did you actually create this tool when you already have
+
+406
+00:32:16.800 --> 00:32:21.680
+Amplify? And it seems like they explained pretty clearly that strategically they're basically
+
+407
+00:32:21.680 --> 00:32:25.200
+saying, if you want to manage service, use Amplify. But if you want a little bit more
+
+408
+00:32:25.200 --> 00:32:28.960
+control over the infrastructure and you're really just looking for something to generate that
+
+409
+00:32:28.960 --> 00:32:34.880
+blueprint infrastructure, then that's what the CloudFront hosting toolkit is aimed to solve for
+
+410
+00:32:34.880 --> 00:32:39.200
+you. So at least that gives you the right kind of context for deciding which approach you might like
+
+411
+00:32:39.200 --> 00:32:42.960
+to take. Awesome. And I think that covers everything we wanted to cover for today.
+
+412
+00:32:43.520 --> 00:32:48.240
+Let us know if you had a chance to try the tool yourself and what is your opinion, or if you've
+
+413
+00:32:48.240 --> 00:32:52.640
+used any other alternative tool, what do you use and whether you like it or not. I think this is
+
+414
+00:32:52.640 --> 00:32:57.440
+still a topic that deserves a lot of attention. I don't think there is a final solution that is
+
+415
+00:32:57.440 --> 00:33:03.200
+going to fit all the use cases. So I'm really good to see... Well, unless you use PHP and become a
+
+416
+00:33:03.200 --> 00:33:09.120
+millionaire that way. But yeah, let us know what are you using today. And I'm curious to see how
+
+417
+00:33:09.120 --> 00:33:12.320
+this space is going to evolve in the next few years, because I think there is still a lot of
+
+418
+00:33:12.320 --> 00:33:16.640
+innovation that needs to happen in this space to fit all the different use cases that people
+
+419
+00:33:16.640 --> 00:33:25.680
+have today. So thank you very much, and we'll see you in the next episode.


### PR DESCRIPTION

# Transcript

This change includes the transcript for the podcast episode, created by [Podwhisperer](https://github.com/fourTheorem/podwhisperer).
The summary below is generated by [Episoder](https://github.com/fourTheorem/episoder).

## Episode Summary

In this episode, we discuss the newly announced CloudFront Austin Toolkit from AWS. We provide an overview of the tool, which aims to simplify deploying modern front-end applications to AWS while retaining infrastructure control. We discuss the current capabilities and limitations, and share our hands-on experiences trying out the tool. We also talk about alternatives like Vercel and Amplify, and the tradeoffs between convenience vs control. Overall, the toolkit shows promise but is still early stage. We are excited to see it evolve to support more frameworks and use cases.

## Suggested Chapters
00:00 Introduction to CloudFront Austin Toolkit
05:49 Overview of Vercel and its developer experience
08:35 Introducing the CloudFront Austin Toolkit
09:01 Overview of CloudFront Toolkit features and architecture
13:52 How CloudFront functions and key value store enable atomic deployments
17:34 Walkthrough of using the toolkit with a sample Next.js app
26:22 Discussion of abstraction vs infrastructure control tradeoffs
28:18 Additional feedback on the toolkit based on experience
32:43 Conclusion and request for feedback from listeners

## Suggested Tags
AWS, CloudFront, Vercel, Next.js, React, Atomic Deployments, Immutable Infrastructure, Infrastructure as Code, CDN, Edge Computing, JAMStack, Serverless, Frontend, Node.js, JavaScript, TypeScript, CloudFormation, S3, CodeBuild, CodePipeline, Amplify, Static Sites
