### PR TITLE
add episode 134 transcript

### DIFF
--- a/src/_transcripts/134.json
+++ b/src/_transcripts/134.json
@@ -1,0 +1,2882 @@
+{
+  "speakers": {
+    "spk_0": "spk_0",
+    "spk_1": "spk_1"
+  },
+  "segments": [
+    {
+      "speakerLabel": "spk_0",
+      "start": 0,
+      "end": 5.04,
+      "text": " Hello, friends of AWS Bites podcast, the show where we share stories and hard-heard lessons"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 5.04,
+      "end": 5.96,
+      "text": " from the cloud trenches."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 6.08,
+      "end": 8.700000000000001,
+      "text": " Today, we are here to sound the alarm on something very serious."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 9.1,
+      "end": 13.22,
+      "text": " You need to eliminate IAM users from your AWS accounts and fast."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 13.42,
+      "end": 16.66,
+      "text": " Seriously, if you are still using them, it's like an incident just waiting to happen."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 16.82,
+      "end": 20.6,
+      "text": " It's like handing your credit card details to a stranger online and hoping they will"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 20.6,
+      "end": 21.44,
+      "text": " surprise you with a gift."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 21.6,
+      "end": 22.3,
+      "text": " But I'll give you a spoiler."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 22.5,
+      "end": 24.060000000000002,
+      "text": " You won't like the gift that you will get."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 24.22,
+      "end": 25.32,
+      "text": " So just be very careful."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 25.560000000000002,
+      "end": 26.14,
+      "text": " Don't do that."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 26.3,
+      "end": 29.54,
+      "text": " And we have talked already about governance and lending zone in the past."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 29.54,
+      "end": 34.46,
+      "text": " But today, we want to focus specifically on why IAM users and long-lived credentials"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 34.46,
+      "end": 38.1,
+      "text": " are one of the biggest foot guns that exists today in AWS."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 38.3,
+      "end": 42,
+      "text": " And hopefully, we'll also share some strategies on how you can start to get rid of them if"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 42,
+      "end": 42.58,
+      "text": " you are still using them."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 42.62,
+      "end": 46.58,
+      "text": " My name is Luciano, and today I'm joined by Connor, our new co-host, who brings tons of"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 46.58,
+      "end": 48.519999999999996,
+      "text": " experience in managing AWS accounts."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 48.620000000000005,
+      "end": 49.58,
+      "text": " So I'm really excited."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 49.8,
+      "end": 50.72,
+      "text": " Let's get into it."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 50.72,
+      "end": 60.82,
+      "text": " AWS Bites is brought to you by Forteorem."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 60.98,
+      "end": 65.82,
+      "text": " If you are looking for a partner to architect, develop, and modernize on AWS, give Forteorem"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 65.82,
+      "end": 66.22,
+      "text": " a call."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 66.44,
+      "end": 68.46000000000001,
+      "text": " Check us out at forteorem.com."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 68.58,
+      "end": 70.96000000000001,
+      "text": " So as I said, we already covered similar topics."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 71.16,
+      "end": 75.25999999999999,
+      "text": " But today, we have Connor, who brings lots of expertise and fresh perspective."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 75.26,
+      "end": 79.94,
+      "text": " So maybe it's a good idea to start with just Connor introducing yourself so people can"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 79.94,
+      "end": 81.84,
+      "text": " know all the amazing things that you have done."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 82.38000000000001,
+      "end": 82.5,
+      "text": " Sure."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 82.94,
+      "end": 83.5,
+      "text": " Yeah."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 83.68,
+      "end": 87.24000000000001,
+      "text": " Long-time listener, first-time caller, I guess, to AWS Bites."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 87.64,
+      "end": 89.96000000000001,
+      "text": " So I joined Forteorem about 18 months ago."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 90.36,
+      "end": 92.58000000000001,
+      "text": " I'm a senior infrastructure engineer."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 93.02000000000001,
+      "end": 96.52000000000001,
+      "text": " And I guess I've worked with a lot of startups over my career."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 96.68,
+      "end": 102.52000000000001,
+      "text": " Very interested in the security space in AWS and infrastructure as code and all things safety"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 102.52000000000001,
+      "end": 104.38000000000001,
+      "text": " and security in the cloud, I guess."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 104.38,
+      "end": 108.96,
+      "text": " So I've had the privilege of joining a lot of excellent teams over the years."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 109.11999999999999,
+      "end": 114.96,
+      "text": " But a lot of times, I may have been the first security nerd or AWS practitioner to join the"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 114.96,
+      "end": 115.22,
+      "text": " team."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 115.46,
+      "end": 121.75999999999999,
+      "text": " So I have often encountered very mature AWS accounts with lots of IAM users."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 122.56,
+      "end": 127.64,
+      "text": " And what we want to chat about today, I guess, is there's a lot of modern techniques and tooling"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 127.64,
+      "end": 133.01999999999998,
+      "text": " that help us totally eliminate those IAM users, which have become a bit of a security"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 133.02,
+      "end": 138.88000000000002,
+      "text": " nightmare or certainly a potential rake in the grass for a lot of organizations."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 139.38000000000002,
+      "end": 140.92000000000002,
+      "text": " So yeah, that's me."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 140.92000000000002,
+      "end": 141.20000000000002,
+      "text": " Yeah."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 141.26000000000002,
+      "end": 145.28,
+      "text": " I can only add that you are one of the people I know with the most Terraform expertise."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 145.68,
+      "end": 149.38,
+      "text": " So I'm really lucky to have you as a colleague every time I have a question about Terraform."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 149.38,
+      "end": 152.12,
+      "text": " So that's just to send a little bit more context."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 152.38,
+      "end": 157.32,
+      "text": " But yeah, going back to IAM users, I guess one main question that people might have is"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 157.32,
+      "end": 158.94,
+      "text": " like, what is really the problem, right?"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 158.98,
+      "end": 161.6,
+      "text": " It seems like something that has been in AWS forever."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 161.79999999999998,
+      "end": 164.35999999999999,
+      "text": " So why should it be a problem in the first place, right?"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 164.46,
+      "end": 167.84,
+      "text": " And we said it is one of the biggest foot guns that you have today."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 167.96,
+      "end": 172.4,
+      "text": " And the main reason to that is that when you use IAM users, generally, you are also using"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 172.4,
+      "end": 173.42,
+      "text": " long-lived credentials."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 173.42,
+      "end": 178.1,
+      "text": " So you go into that specific user and maybe through the web UI and you generate credentials"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 178.1,
+      "end": 178.82,
+      "text": " for that user."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 179.2,
+      "end": 183.6,
+      "text": " And then God knows where you're going to copy-paste those credentials, store them somewhere forever,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 183.79999999999998,
+      "end": 184.92,
+      "text": " maybe forget about them."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 185.33999999999997,
+      "end": 187.94,
+      "text": " And I don't know, they can end up in development machines."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 187.94,
+      "end": 189.2,
+      "text": " They can end up in servers."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 189.32,
+      "end": 192.67999999999998,
+      "text": " They can end up inside applications that somehow need to interact with AWS."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 193.16,
+      "end": 195.98,
+      "text": " And the problem with that is that they are generally clear text."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 196.35999999999999,
+      "end": 199.7,
+      "text": " So easy to exploit or exfiltrate or copy-paste."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 200.01999999999998,
+      "end": 203.07999999999998,
+      "text": " And the other problem is that generally they are very broadly scoped."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 203.08,
+      "end": 205.46,
+      "text": " So you can have permissions to do lots of things."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 205.46,
+      "end": 209.78,
+      "text": " Even if originally you didn't intend to do all these different things, maybe it was convenient"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 209.78,
+      "end": 213.22000000000003,
+      "text": " to just give this particular user lots of open permissions."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 213.68,
+      "end": 217.42000000000002,
+      "text": " And then whoever has access to the credentials inherits all of these permissions."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 217.78,
+      "end": 222.28,
+      "text": " So imagine, yeah, you might end up with somebody just spinning up the most expensive EC2 instance"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 222.28,
+      "end": 225.16000000000003,
+      "text": " just because that particular user has permissions to do that."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 225.34,
+      "end": 228.24,
+      "text": " And the other problem is that those credentials get rarely rotated."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 228.62,
+      "end": 231.62,
+      "text": " There are ways that you can rotate the credentials, but there's generally something that people"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 231.62,
+      "end": 232.66000000000003,
+      "text": " don't bother doing."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 232.66,
+      "end": 237.42,
+      "text": " And I personally have seen, it's funny that you can go to the web UI and see how long"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 237.42,
+      "end": 238.7,
+      "text": " those credentials existed."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 239.04,
+      "end": 242.62,
+      "text": " Like, it's not rare to see like these credentials existed for like 2000 days."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 242.76,
+      "end": 247.5,
+      "text": " And yeah, you can think of how many things could have gone wrong in so much time."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 247.5,
+      "end": 251.88,
+      "text": " Like how many people could have had opportunities to take these credentials and use them to do"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 251.88,
+      "end": 252.22,
+      "text": " something."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 252.22,
+      "end": 257.26,
+      "text": " So the other interesting use case that we have seen a lot is that if you create IAM users"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 257.26,
+      "end": 261.04,
+      "text": " for, I don't know, developers in your company, people will come and go in the company."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 261.28,
+      "end": 265.34,
+      "text": " And sometimes you don't have a very strict process for offboarding people from your AWS"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 265.34,
+      "end": 265.8,
+      "text": " accounts."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 266.22,
+      "end": 272.1,
+      "text": " So I know of people that were able to access accounts in AWS from not their first company,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 272.1,
+      "end": 275.88,
+      "text": " but like two previous companies that they were working before, like years before."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 275.88,
+      "end": 280.18,
+      "text": " And still their credentials were totally valid and they could see everything in the account"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 280.18,
+      "end": 283.88,
+      "text": " and do all kinds of actions that they could do as developers, even though they were not"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 283.88,
+      "end": 285.34,
+      "text": " employed anymore in that company."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 285.58,
+      "end": 288.06,
+      "text": " So just be aware that these are just some of the risks."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 288.3,
+      "end": 290.98,
+      "text": " But I don't know, Connor, if you have anything else you would like to add."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 290.98,
+      "end": 294.58000000000004,
+      "text": " Yeah, I guess it is one of those difficult challenges."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 295.58000000000004,
+      "end": 301.78000000000003,
+      "text": " You know, a lot of my history was in IT and onboarding and offboarding people from teams."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 302.1,
+      "end": 309.16,
+      "text": " So you tend to bias towards single sign on and role based access control and credentials"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 309.16,
+      "end": 313.44,
+      "text": " that you can expire or at least reason about their status."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 313.72,
+      "end": 320.5,
+      "text": " And like you mentioned, IAM users are incredibly challenging to keep on top of, especially in larger"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 320.5,
+      "end": 321.46,
+      "text": " organizations."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 321.46,
+      "end": 327.36,
+      "text": " So just to add to your war stories there, like I've seen, I've seen it all, I guess, you"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 327.36,
+      "end": 333.1,
+      "text": " know, that the worst is when you find the root account that has an access key and secret"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 333.1,
+      "end": 335.98,
+      "text": " access key generated and it's being used in a pipeline."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 335.98,
+      "end": 343.86,
+      "text": " But I've always seen, you know, front end engineer Bob has a large team and they're great"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 343.86,
+      "end": 346.4,
+      "text": " and they're tenacious about getting work done."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 346.4,
+      "end": 352.71999999999997,
+      "text": " But eventually, you know, Bob moves on and suddenly all of the other front end engineers"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 352.71999999999997,
+      "end": 354.65999999999997,
+      "text": " development environments stop working."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 354.82,
+      "end": 359.35999999999996,
+      "text": " It's typically because Bob has been really helpful and, you know, shared his IAM access"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 359.35999999999996,
+      "end": 362.65999999999997,
+      "text": " keys with the team, maybe check them into that repo for that app."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 363.06,
+      "end": 368.94,
+      "text": " So very difficult to manage that as a, you know, a central cloud team or a practitioner that's"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 368.94,
+      "end": 370.85999999999996,
+      "text": " trying to keep on top of the AWS environment."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 370.86,
+      "end": 374.96000000000004,
+      "text": " So I guess it's not usually somebody's fault."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 375.12,
+      "end": 380.3,
+      "text": " You know, it's up to the platform team or the security team to try and put the correct"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 380.3,
+      "end": 384.06,
+      "text": " guardrails in place so that it's easy to do the right thing and very difficult to do the"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 384.06,
+      "end": 384.54,
+      "text": " wrong thing."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 384.78000000000003,
+      "end": 388.44,
+      "text": " And I guess later on in the episode, we're going to get into a lot of the modern techniques"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 388.44,
+      "end": 392.64,
+      "text": " for doing things the right way that just make it much more difficult to create these"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 392.64,
+      "end": 394.26,
+      "text": " kind of edge cases in the first place."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 394.7,
+      "end": 397.74,
+      "text": " But yeah, IAM users will end up on developer machines."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 397.74,
+      "end": 400.84000000000003,
+      "text": " They'll end up in Dropbox, Google Drive, Slack messages."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 401.46000000000004,
+      "end": 406.2,
+      "text": " You know, you'll have users that were intended for human access that end up in pipelines or"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 406.2,
+      "end": 407.16,
+      "text": " production systems."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 407.7,
+      "end": 414.08,
+      "text": " So I guess our goal today is to tell everybody that there is a better way and you can get"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 414.08,
+      "end": 416.04,
+      "text": " to the point that you have no IAM users at all."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 416.32,
+      "end": 420.04,
+      "text": " Depending on your environment, that's going to be a simple or very arduous journey."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 420.26,
+      "end": 421.98,
+      "text": " But I guess we want to help you to get there."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 422.28000000000003,
+      "end": 426.58,
+      "text": " So I guess the reason you end up with these in the first place is because somebody wants to"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 426.58,
+      "end": 429.38,
+      "text": " do programmatic access to AWS, right?"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 429.44,
+      "end": 435.85999999999996,
+      "text": " Whether it's from a pipeline that's running on an EC2 instance or ECS Fargate, or more"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 435.85999999999996,
+      "end": 441.28,
+      "text": " commonly, the development flow where you want to interact with S3 or CloudFormation or you"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 441.28,
+      "end": 443.68,
+      "text": " want to run CDK deploy from your laptop."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 443.86,
+      "end": 446.28,
+      "text": " You need programmatic access to the AWS account."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 446.58,
+      "end": 451.14,
+      "text": " All requests to AWS have to be signed with the SIG V4 algorithm."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 451.14,
+      "end": 455.44,
+      "text": " So I think what we want to focus on initially is how does it work?"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 455.52,
+      "end": 462.4,
+      "text": " If I run AWS S3 LS from the CLI, what goes on under the hood there in the SDK for it to"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 462.4,
+      "end": 466.44,
+      "text": " try and find credentials and authenticate itself against AWS APIs?"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 467.14,
+      "end": 470.06,
+      "text": " Do you want to chat about your experience with that, Luciano?"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 470.38,
+      "end": 473.03999999999996,
+      "text": " Yeah, that's a very interesting topic."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 473.4,
+      "end": 475.52,
+      "text": " I actually really like that kind of stuff."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 475.58,
+      "end": 477.14,
+      "text": " Like you mentioned, the SIG V4 algorithm."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 477.14,
+      "end": 481.36,
+      "text": " We're not going to go into detail on that one today, but we'll post a link in the show"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 481.36,
+      "end": 482.14,
+      "text": " notes if you're curious."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 482.46,
+      "end": 487.24,
+      "text": " What we want to focus a bit more on is that there needs to be a process for if you're using"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 487.24,
+      "end": 492.59999999999997,
+      "text": " the SDK or the CLI to locate credentials in that execution environment."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 492.88,
+      "end": 498.44,
+      "text": " And there are specific pages that you can find in the AWS docs, depending if you're using a"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 498.44,
+      "end": 503.38,
+      "text": " specific SDK, like for instance, the JavaScript one, there is a page that details exactly all the"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 503.38,
+      "end": 508.46,
+      "text": " steps that are performed to try to find a viable set of credentials when you create a client"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 508.46,
+      "end": 509.24,
+      "text": " using the SDK."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 509.65999999999997,
+      "end": 513.66,
+      "text": " And there is a similar page for the CLI, so we'll make sure to share the links as well."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 513.78,
+      "end": 516.1,
+      "text": " But just to summarize, what are the different steps?"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 516.22,
+      "end": 522.16,
+      "text": " So you can have an idea of all the different things that can provide credentials to a given"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 522.16,
+      "end": 522.62,
+      "text": " environment."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 522.82,
+      "end": 527.62,
+      "text": " So the first thing is that as you create a client, you are effectively instantiating a"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 527.62,
+      "end": 527.92,
+      "text": " class."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 528.24,
+      "end": 531.84,
+      "text": " Let's imagine in JavaScript, you say, I don't know, new S3 client, something like that."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 531.84,
+      "end": 536,
+      "text": " You can provide options there as the constructor of that function call."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 536.3000000000001,
+      "end": 541.44,
+      "text": " And some of the options there are specifically put in place so that you can provide inline"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 541.44,
+      "end": 541.88,
+      "text": " credentials."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 542.12,
+      "end": 546.24,
+      "text": " So if you do that, this is the first thing that the client is going to look for."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 546.4,
+      "end": 549.1800000000001,
+      "text": " And if you provide the credentials there, those credentials will be used."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 549.34,
+      "end": 551.4200000000001,
+      "text": " But those credentials there are not mandatory."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 551.64,
+      "end": 553.1600000000001,
+      "text": " So what happens if you don't provide them?"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 553.2800000000001,
+      "end": 558.32,
+      "text": " And the next step is that if credentials are not there in the constructor options, the client"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 558.32,
+      "end": 560.38,
+      "text": " is going to look for specific environment variables."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 560.38,
+      "end": 565.02,
+      "text": " And I'm sure you have seen the AWS secret key and that kind of environment variables."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 565.3,
+      "end": 567.5,
+      "text": " So this is the next thing that the client is going to look for."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 567.58,
+      "end": 571.68,
+      "text": " So if in the current execution environment, you have those variables set, those will be"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 571.68,
+      "end": 573.86,
+      "text": " used for your client to interact with AWS."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 574.16,
+      "end": 577.28,
+      "text": " Then the next step is that if you don't have those environment variables, then it's going"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 577.28,
+      "end": 578.74,
+      "text": " to look for shared credentials files."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 579.42,
+      "end": 585.44,
+      "text": " You can imagine similar to when you configure your CLI that you might have credentials files that"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 585.44,
+      "end": 585.68,
+      "text": " way."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 585.68,
+      "end": 589.9,
+      "text": " And then you can have in specific environments, for instance, if you're running your code in"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 589.9,
+      "end": 594.78,
+      "text": " ECS, ECS has mechanisms to provide credentials through, for instance, roles."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 594.9799999999999,
+      "end": 596.2399999999999,
+      "text": " You can have short-lived credentials."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 596.5999999999999,
+      "end": 601.4599999999999,
+      "text": " So if you have done all of that, configure correctly, the SDK can actually load these credentials."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 601.9,
+      "end": 602.9599999999999,
+      "text": " So that would be another step."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 602.96,
+      "end": 604.7,
+      "text": " And we can keep going."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 604.84,
+      "end": 605.72,
+      "text": " There are other steps."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 606.1800000000001,
+      "end": 611.52,
+      "text": " You can use credential processes, which is just a mechanism where you can have custom ways"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 611.52,
+      "end": 613.8000000000001,
+      "text": " to say, I can call a specific process."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 613.98,
+      "end": 618.24,
+      "text": " And that process is responsible for somehow fetching credentials that I can use."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 618.5600000000001,
+      "end": 621.74,
+      "text": " And this is generally when you want to integrate with, I don't know, third-party tools."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 622.26,
+      "end": 626.6800000000001,
+      "text": " Maybe you have some kind of vault or secret manager and you store configuration there."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 626.68,
+      "end": 632.5,
+      "text": " That configuration can contain your AWS credentials and you can create that mechanism to load credentials"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 632.5,
+      "end": 633.38,
+      "text": " from a custom place."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 633.64,
+      "end": 639.4799999999999,
+      "text": " And then finally, another example is if you're using EC2 as a concept of instance metadata."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 640.0799999999999,
+      "end": 644.4599999999999,
+      "text": " So that's basically a mechanism where if you provide a role to an EC2 instance, that role"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 644.4599999999999,
+      "end": 646.6999999999999,
+      "text": " can have effectively permissions attached to it."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 646.78,
+      "end": 652.16,
+      "text": " And the way that your client inside that EC2 inherits those permissions is by accessing this"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 652.16,
+      "end": 657.02,
+      "text": " metadata server, let's call it, it's kind of a local server that if you call it through"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 657.02,
+      "end": 661.7199999999999,
+      "text": " an HTTP endpoint, it's going to give you temporary credentials that are scoped specifically with"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 661.7199999999999,
+      "end": 663.18,
+      "text": " the role attached to the instance."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 663.52,
+      "end": 668.26,
+      "text": " And I guess some of these ideas are better than others because they will give you shorter"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 668.26,
+      "end": 669.48,
+      "text": " term credentials."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 669.9,
+      "end": 675.2199999999999,
+      "text": " But because the most common or at least historically the most used option is just copy-paste some"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 675.2199999999999,
+      "end": 679.98,
+      "text": " credentials into the environment, people tend to do IAM users, copy-paste credentials and"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 679.98,
+      "end": 684.7,
+      "text": " use them even for programmatic access on a kind of server process or something that should"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 684.7,
+      "end": 686.4200000000001,
+      "text": " have been managed differently."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 686.78,
+      "end": 691.34,
+      "text": " So that's, I guess, probably trying to shed some light on the fact that, yeah, there are"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 691.34,
+      "end": 694.76,
+      "text": " different ways to provide credentials and it's kind of a step-by-step."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 694.88,
+      "end": 697.52,
+      "text": " If the first step fails, it's going to look for the second step and so on."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 697.54,
+      "end": 701.78,
+      "text": " So it's important to also understand what is the priority of what the SDK or the CLI is"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 701.78,
+      "end": 702.26,
+      "text": " looking for."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 702.62,
+      "end": 706.88,
+      "text": " So again, link to the links in the description if you're curious to find out exactly from the"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 706.88,
+      "end": 708.1800000000001,
+      "text": " docs what are the different steps."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 708.18,
+      "end": 713.8599999999999,
+      "text": " So the question now could be, okay, I kind of get the point that I shouldn't use IAM users,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 714.04,
+      "end": 718.64,
+      "text": " but if I am, what are some of the mitigation strategies that I can start to use today?"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 718.8399999999999,
+      "end": 718.9599999999999,
+      "text": " Yeah."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 719.04,
+      "end": 724.3599999999999,
+      "text": " So I guess the community kind of arrived at a lot of interesting patterns."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 725.16,
+      "end": 729.9599999999999,
+      "text": " I was trying to find the article this morning, but it seems to be removed probably because"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 729.9599999999999,
+      "end": 731.54,
+      "text": " there's better strategies available now."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 731.62,
+      "end": 734.2199999999999,
+      "text": " But I think it was Coinbase back in 2017."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 734.22,
+      "end": 738.9200000000001,
+      "text": " I had a great article on their engineering blog about the Bastion IAM account."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 739.3000000000001,
+      "end": 742.82,
+      "text": " So that might be a more typical pattern for an SSH jump host or something."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 742.94,
+      "end": 745.9,
+      "text": " People would usually mention Bastion in that context, I guess."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 746.02,
+      "end": 751.4200000000001,
+      "text": " But what Coinbase had established, and it was a pattern that I saw used a lot across the industry,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 751.76,
+      "end": 754.1,
+      "text": " was they would elect an account."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 754.26,
+      "end": 755.9200000000001,
+      "text": " Let's call it the Bastion account."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 756.14,
+      "end": 758.64,
+      "text": " Maybe it was the management account of the organization."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 758.64,
+      "end": 759.6,
+      "text": " It didn't really matter."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 759.88,
+      "end": 765.42,
+      "text": " And what you could do is you would create your concrete IAM users in that account."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 765.6999999999999,
+      "end": 768.14,
+      "text": " So we'd create an account for Connor and an account for Luciano."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 768.38,
+      "end": 770.1,
+      "text": " Straight away, that was a big win, right?"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 770.14,
+      "end": 772.86,
+      "text": " Because you were at least centralizing the IAM user."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 773.14,
+      "end": 777.84,
+      "text": " And when you had access to maybe dozens of accounts, we still had one Connor and one Luciano"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 777.84,
+      "end": 779.16,
+      "text": " instead of dozens of each."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 779.42,
+      "end": 785.16,
+      "text": " And so the pattern that was established there was to try and enable role-based access control."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 785.16,
+      "end": 790.92,
+      "text": " So typically then you'd create maybe an admin or a power user or a view-only role in each"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 790.92,
+      "end": 792.7199999999999,
+      "text": " of the accounts that we operate in."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 792.9599999999999,
+      "end": 798.36,
+      "text": " And then what they would do is they would set strict conditions in the trust relationships"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 798.36,
+      "end": 799.4599999999999,
+      "text": " of those roles."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 799.66,
+      "end": 806.4599999999999,
+      "text": " And that might say, the only person who can assume me is Luciano or Connor from this Bastion"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 806.4599999999999,
+      "end": 806.8199999999999,
+      "text": " account."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 806.98,
+      "end": 813.3,
+      "text": " And you could attach other STS conditions like a multi-factor token must be present and must"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 813.3,
+      "end": 813.8199999999999,
+      "text": " be valid."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 813.82,
+      "end": 819.36,
+      "text": " So that was one of the ways that practitioners tried to create this kind of role-based access"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 819.36,
+      "end": 822.2600000000001,
+      "text": " control, centralize it through a single IAM user."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 822.7800000000001,
+      "end": 829.6800000000001,
+      "text": " And at least then we had our sane access pattern, easy to onboard users, easy revocation."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 830.1600000000001,
+      "end": 835.0600000000001,
+      "text": " So that was a pattern that was kind of a battle-tested pattern."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 835.36,
+      "end": 840.1800000000001,
+      "text": " And then on the client side, I guess, or on your developer machine, you've still got that"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 840.1800000000001,
+      "end": 841.98,
+      "text": " plain text long-lived credential."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 841.98,
+      "end": 844.22,
+      "text": " Okay, so how do we protect that?"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 844.46,
+      "end": 850.1800000000001,
+      "text": " So another excellent tool that people might recognize was by 99designs, and that was a"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 850.1800000000001,
+      "end": 851.48,
+      "text": " tool called AWS Vault."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 851.72,
+      "end": 856.3000000000001,
+      "text": " And I guess the innovation there was they allowed you to use whatever keychain you had on your"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 856.3000000000001,
+      "end": 859.72,
+      "text": " system, whether it was Linux or even the macOS keychain."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 859.72,
+      "end": 865.1600000000001,
+      "text": " It would essentially escrow the access key and secret access key in the keychain."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 865.1600000000001,
+      "end": 870.96,
+      "text": " And then instead of directly exposing those credentials to the SDK or the CLI, like we just"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 870.96,
+      "end": 877.26,
+      "text": " spoke about, it would either make some sort of STS get temporary credentials API call, or"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 877.26,
+      "end": 883.84,
+      "text": " you would perform the STS assume role operation to assume that concrete role in the target account,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 884.0600000000001,
+      "end": 884.1800000000001,
+      "text": " right?"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 884.18,
+      "end": 886.66,
+      "text": " Let's say the admin role in my development account."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 886.66,
+      "end": 890.9,
+      "text": " And so now you had a scenario where your access keys were protected in the keychain."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 891.02,
+      "end": 896.4399999999999,
+      "text": " You were only ever retrieving temporary credentials and exposing them to the runtime, whether it"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 896.4399999999999,
+      "end": 901.3199999999999,
+      "text": " was the SDK or the CLI, where a lot of these tools actually injected the environment variables"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 901.3199999999999,
+      "end": 901.9799999999999,
+      "text": " into the shell."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 902.14,
+      "end": 903.2199999999999,
+      "text": " Multiple reasons for that."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 903.42,
+      "end": 907.04,
+      "text": " One reason is because all of the SDKs understand that, as we just covered."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 907.04,
+      "end": 910.92,
+      "text": " But also it has one of the highest precedences in the credential chain."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 911.28,
+      "end": 915.2199999999999,
+      "text": " So more often than not, that's the behavior you wanted when you were running locally."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 915.54,
+      "end": 919.52,
+      "text": " So that was kind of the mitigation strategy that the community arrived at."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 919.5799999999999,
+      "end": 920.98,
+      "text": " It was a very common pattern."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 921.52,
+      "end": 927.04,
+      "text": " And I guess I'm showing my bias here where I've always worked at smaller startups and organizations."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 927.66,
+      "end": 934.68,
+      "text": " Obviously, at larger enterprises, you'd have your SAML identity provider, which would provide"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 934.68,
+      "end": 936.8199999999999,
+      "text": " similar entry point to the system."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 937,
+      "end": 939.8599999999999,
+      "text": " You would still assume roles in target accounts."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 940.28,
+      "end": 942.52,
+      "text": " So that's one way it worked."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 942.5999999999999,
+      "end": 945.3399999999999,
+      "text": " And you can still operate that methodology."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 945.62,
+      "end": 947.16,
+      "text": " It has a good few moving parts."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 947.16,
+      "end": 951.26,
+      "text": " You need to really understand trust relationships and multi-account strategy."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 951.26,
+      "end": 955.4,
+      "text": " And you've got to have all your infrastructure's code tooling in place to make that a feasible"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 955.4,
+      "end": 955.8399999999999,
+      "text": " pattern."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 956.3,
+      "end": 959.14,
+      "text": " But there are modern alternatives today."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 959.6999999999999,
+      "end": 961.14,
+      "text": " Finally, spoiler alert."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 961.14,
+      "end": 964.8199999999999,
+      "text": " I'm really curious to learn what those alternatives looks like."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 965.14,
+      "end": 970.92,
+      "text": " Because yeah, I'm sure that there are more scalable ways today to deal with, especially if you start"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 970.92,
+      "end": 976.28,
+      "text": " to have multiple accounts, lots of potential users, different kinds of access levels that you need"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 976.28,
+      "end": 976.74,
+      "text": " to ensure."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 976.98,
+      "end": 979.9399999999999,
+      "text": " And you might have lots of people coming and going in the organization as well."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 980.12,
+      "end": 985.34,
+      "text": " So yes, what are those better ways to deal with user access in general and permissions?"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 991.0600000000001,
+      "end": 993.64,
+      "text": " Yeah, so I think there's been previous episodes on creating a landing zone and then some of the infrastructure's code tooling around that."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 993.98,
+      "end": 1000.8000000000001,
+      "text": " But a core component of all of those modern landing zone setups is AWS IAM Identity Center"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1000.8000000000001,
+      "end": 1004.9200000000001,
+      "text": " and more so its integration with AWS organizations."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1005.5600000000001,
+      "end": 1011.96,
+      "text": " So what the Identity Center service lets you do is essentially implement the pattern we spoke"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1011.96,
+      "end": 1012.26,
+      "text": " about."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1012.26,
+      "end": 1019.58,
+      "text": " So Identity Center has the concept of permission sets and permission sets are almost like a"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1019.58,
+      "end": 1023.66,
+      "text": " wrapper for a role and then it can have targets."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1023.9399999999999,
+      "end": 1027.34,
+      "text": " So the target could be another AWS account or an organizational unit."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1027.66,
+      "end": 1029.74,
+      "text": " But essentially, we now have single sign-on."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1029.98,
+      "end": 1032.8,
+      "text": " Okay, Identity Center lets us create an individual identity."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1033.2,
+      "end": 1036.18,
+      "text": " You can use Identity Center's built-in Identity Store."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1036.42,
+      "end": 1037.44,
+      "text": " It's a great way to start."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1037.44,
+      "end": 1042.76,
+      "text": " If you're a small organization, you may not necessarily have an IDP, Azure or AD."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1043.38,
+      "end": 1049.6200000000001,
+      "text": " And if you just want a sane way to manage users into your AWS organization, you can use the"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1049.6200000000001,
+      "end": 1050.6200000000001,
+      "text": " built-in Identity Store."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1050.96,
+      "end": 1054.96,
+      "text": " So you then have your kind of standard, you know, groups."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1055.22,
+      "end": 1060.1000000000001,
+      "text": " You could have a group for certain application teams, security group, platform team."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1060.1,
+      "end": 1063.32,
+      "text": " And you can map the groups and permission sets to accounts."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1063.6399999999999,
+      "end": 1068.02,
+      "text": " And then Identity Center and its integration with organizations does the rest of the heavy"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1068.02,
+      "end": 1068.74,
+      "text": " lifting for you."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1069.06,
+      "end": 1074.78,
+      "text": " So if you have 10 accounts or 200 accounts, the admin role will be created automatically"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1074.78,
+      "end": 1076.24,
+      "text": " by the permission set."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1076.3799999999999,
+      "end": 1079.28,
+      "text": " And then the appropriate users will be able to access it."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1079.54,
+      "end": 1079.6599999999999,
+      "text": " Okay."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1079.66,
+      "end": 1086.0400000000002,
+      "text": " So Identity Center really does all of the heavy lifting for you here as regards access to a"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1086.0400000000002,
+      "end": 1087.92,
+      "text": " large AWS estate."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1088.3200000000002,
+      "end": 1094.3400000000001,
+      "text": " So the other option you have, which is convenient then, is that you can integrate most identity"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1094.3400000000001,
+      "end": 1094.8400000000001,
+      "text": " providers."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1095.14,
+      "end": 1095.24,
+      "text": " Okay."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1095.3000000000002,
+      "end": 1097.5800000000002,
+      "text": " So at 4th Erem, we have Google Workspace integrated."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1098.0400000000002,
+      "end": 1103.88,
+      "text": " You can have manual user management, or you can even use something like Skim to get full"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1103.88,
+      "end": 1109.22,
+      "text": " automated user just-in-time provisioning into the Identity Center."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1109.22,
+      "end": 1114.04,
+      "text": " So it's quite flexible and, you know, nice to be able to integrate it with an existing"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1114.04,
+      "end": 1115.44,
+      "text": " identity provider."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1115.94,
+      "end": 1121.3600000000001,
+      "text": " So that then gives you a lovely, you know, SSO landing page that you might be familiar with,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1121.5,
+      "end": 1125.82,
+      "text": " and it'll present all of the AWS accounts and all of the roles that you have access to."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1126.08,
+      "end": 1130.3,
+      "text": " So it solves the console access problem quite well."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1130.46,
+      "end": 1135.78,
+      "text": " And then I guess, you know, the next step is getting your programmatic access."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1135.78,
+      "end": 1141.1,
+      "text": " So one thing that the Identity Center portal will let you do is grab temporary credentials"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1141.1,
+      "end": 1144.3,
+      "text": " in the context of any role that you have access to."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1144.56,
+      "end": 1150.08,
+      "text": " So it's like the Identity Center console has essentially performed the, you know, STS assume"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1150.08,
+      "end": 1153.1399999999999,
+      "text": " role or assume role with web identity operation for you."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1153.14,
+      "end": 1157.38,
+      "text": " And it's going to give you back an access key, a secret key, and a session token."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1157.8400000000001,
+      "end": 1163.2800000000002,
+      "text": " And if you want, you can just paste that in a shell or, you know, configure it in an AWS"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1163.2800000000002,
+      "end": 1165.88,
+      "text": " credentials file, and you have your programmatic access."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1166.2,
+      "end": 1172.0200000000002,
+      "text": " Now, that is fine for, you know, maybe a tiny investigation or access to an account you don't"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1172.0200000000002,
+      "end": 1172.8600000000001,
+      "text": " often use."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1172.98,
+      "end": 1177.76,
+      "text": " But the tool that we recommend to a lot of customers and we use internally ourselves is"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1177.76,
+      "end": 1179.8000000000002,
+      "text": " a tool called Granted by CommonFate."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1179.8,
+      "end": 1184.46,
+      "text": " And the really nice thing about that tool is that you sign in, you perform the single sign-on"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1184.46,
+      "end": 1188.44,
+      "text": " flow, and it's able to enumerate all of the accounts and roles you have access to."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1188.58,
+      "end": 1190.8999999999999,
+      "text": " It's able to automatically generate the config file."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1191.34,
+      "end": 1196.4199999999998,
+      "text": " And now you have this tool that you can run in your shell, and it can inject credentials"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1196.4199999999998,
+      "end": 1199.84,
+      "text": " into the shell for any role in any account that you have access to."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1200,
+      "end": 1204.04,
+      "text": " So we find it, you know, a really great way to access accounts."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1204.2,
+      "end": 1206.46,
+      "text": " You're only ever getting back a temporary credential."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1206.46,
+      "end": 1212.4,
+      "text": " And it just, in an environment where you have lots of accounts, which we often encourage,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1212.58,
+      "end": 1216.8600000000001,
+      "text": " it just makes the, you know, the user experience really nice."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1217.24,
+      "end": 1219.3,
+      "text": " So what else did we want to chat about there?"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1219.54,
+      "end": 1222.78,
+      "text": " So when you, if you do that, like this is what we think great looks like, I guess."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1222.8400000000001,
+      "end": 1227.2,
+      "text": " It's a lot easier in a greenfields environment to create this."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1227.3400000000001,
+      "end": 1231.8400000000001,
+      "text": " But we would then recommend, you know, creating an SCP policy that blocks the creation of IAM"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1231.8400000000001,
+      "end": 1232.24,
+      "text": " users."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1232.24,
+      "end": 1236.6,
+      "text": " That's a common security best practice now, I guess, because once you've gotten to this"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1236.6,
+      "end": 1239.06,
+      "text": " point, you don't want people to be able to go off piste."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1239.22,
+      "end": 1241.7,
+      "text": " You know, you don't want them to be able to do the bad thing."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1241.88,
+      "end": 1244.98,
+      "text": " Like we said, we want to make the good thing easy."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1244.98,
+      "end": 1247.6,
+      "text": " So we can just block the creation of IAM users."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1248.08,
+      "end": 1252.84,
+      "text": " Now you've got to use your single point of entry into the AWS organization to do what you"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1252.84,
+      "end": 1253.6,
+      "text": " wanted to do."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1253.6,
+      "end": 1256.2199999999998,
+      "text": " Yeah, that sounds easy."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1256.5,
+      "end": 1260.6599999999999,
+      "text": " Again, when you are starting from scratch and you have total freedom, so you can set up"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1260.6599999999999,
+      "end": 1263.6599999999999,
+      "text": " things in a way that looks modern and good from scratch."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1263.6599999999999,
+      "end": 1268.06,
+      "text": " But I would imagine that if you already have, I'm just going to say quite a legacy setup,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1268.3,
+      "end": 1271.9399999999998,
+      "text": " maybe with lots of stuff running there, you have been using it for years."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1272.1999999999998,
+      "end": 1274.6399999999999,
+      "text": " Like how do you start to enforce this kind of things?"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1274.6999999999998,
+      "end": 1278.76,
+      "text": " I'm sure that there are cases where you cannot just get read from one day to the next one of"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1278.76,
+      "end": 1284.24,
+      "text": " all IAM users, you need to, I don't know, probably take a few shortcuts or a few half"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1284.24,
+      "end": 1286.98,
+      "text": " baked solutions that maybe are still better than nothing."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1287.12,
+      "end": 1291.24,
+      "text": " But yeah, you're probably incrementally going to get to a great place to be, but it's not"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1291.24,
+      "end": 1293.34,
+      "text": " going to happen from like one day to the next."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1293.72,
+      "end": 1297.94,
+      "text": " So do you have any recommendations for people that might be more in this camp where it's not"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1297.94,
+      "end": 1301.64,
+      "text": " going to be easy to change things, but they can still have opportunities to make things"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1301.64,
+      "end": 1301.92,
+      "text": " better?"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1302.16,
+      "end": 1302.8799999999999,
+      "text": " Yeah, absolutely."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1303.08,
+      "end": 1308.66,
+      "text": " And it is a thankless job sometimes, you know, to say, look, we've got"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1308.66,
+      "end": 1310.52,
+      "text": " a glaring security issue here."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1310.66,
+      "end": 1311.78,
+      "text": " We want to pay it down."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1312.0400000000002,
+      "end": 1316.48,
+      "text": " So I think it's just important to have buy-in from the team and the organization, you know,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1316.64,
+      "end": 1321.88,
+      "text": " get it on the Kanban board, get it on the backlog and start to approach it systematically"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1321.88,
+      "end": 1323.46,
+      "text": " because it is worth doing."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1323.8200000000002,
+      "end": 1328.24,
+      "text": " You're closing off one of the biggest attack vectors you have in a modern cloud environment,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1328.3400000000001,
+      "end": 1328.68,
+      "text": " I guess."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1328.98,
+      "end": 1330.6000000000001,
+      "text": " So how do you start, right?"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1330.66,
+      "end": 1334.94,
+      "text": " The two problems we really usually have to solve is like the human access problem, which"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1334.94,
+      "end": 1337.78,
+      "text": " tends to be simpler, and then the machine access problem."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1337.78,
+      "end": 1342.6,
+      "text": " Okay, like we spoke about in the intro, you're probably going to have a smattering of IAM"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1342.6,
+      "end": 1343.8999999999999,
+      "text": " users that represent humans."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1344.02,
+      "end": 1345.72,
+      "text": " You might have ones that represent machines."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1345.72,
+      "end": 1349.26,
+      "text": " And if you're really unlucky, you're going to have the ones that were intended for humans"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1349.26,
+      "end": 1350.98,
+      "text": " that are now being used on machines."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1351.28,
+      "end": 1352.82,
+      "text": " So how do we approach it?"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1353.02,
+      "end": 1356.18,
+      "text": " The IAM credential report is super helpful."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1356.32,
+      "end": 1357.76,
+      "text": " We'll put a link to that in the show notes."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1357.8799999999999,
+      "end": 1361.26,
+      "text": " You can generate this using the CLI or from the IAM console."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1361.26,
+      "end": 1365.24,
+      "text": " That will give you a CSV export, which is a great place to start."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1365.46,
+      "end": 1371.86,
+      "text": " You know, you can sort it by access key age, or you can start to examine some of the policies"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1371.86,
+      "end": 1373.26,
+      "text": " that are attached to the users."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1373.68,
+      "end": 1379.3799999999999,
+      "text": " And you can decide to organize them by danger, which sometimes makes sense, right?"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1379.5,
+      "end": 1382.44,
+      "text": " Now, often that first pass will be a big win."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1382.64,
+      "end": 1385.76,
+      "text": " You're going to find people that have left the company months ago or years ago."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1385.76,
+      "end": 1389.1,
+      "text": " You're going to find access keys that haven't been used in some window."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1389.5,
+      "end": 1393.62,
+      "text": " You're going to find machine users that are for services you no longer operate."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1394.08,
+      "end": 1397.92,
+      "text": " And like very quickly, you might be able to shed half of the IAM users."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1398.26,
+      "end": 1398.44,
+      "text": " All right."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1398.6,
+      "end": 1404.64,
+      "text": " Now, I would also recommend implementing identity center permission sets on board yourself and"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1404.64,
+      "end": 1407.7,
+      "text": " maybe other people on the platform team or the security team."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1408.04,
+      "end": 1412.92,
+      "text": " Start to kick the tires on that and introduce it for a trusted group at the organization."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1412.92,
+      "end": 1419.1200000000001,
+      "text": " And then you can start to reimplement your role-based access control in identity center, right?"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1419.18,
+      "end": 1424.7,
+      "text": " So you now have a permission set that represents maybe what the DevOps IAM user does."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1424.8600000000001,
+      "end": 1425.78,
+      "text": " That's a typical thing."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1425.8400000000001,
+      "end": 1431.48,
+      "text": " You might find an overprivileged IAM user that was used by a certain group or a group of individuals."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1431.48,
+      "end": 1435.96,
+      "text": " So you can start to take little slices off of the problem like that, okay?"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1436.76,
+      "end": 1441.16,
+      "text": " You'll often find then, you know, you could find an IAM user called S3 backup."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1441.16,
+      "end": 1446.18,
+      "text": " It's quite obvious what it does, but you might find that it has the Amazon S3 full access"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1446.18,
+      "end": 1448.0600000000002,
+      "text": " managed policy attached."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1448.44,
+      "end": 1452.52,
+      "text": " Now, you know, we could replace that with an IAM role and just move on."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1452.64,
+      "end": 1458.6200000000001,
+      "text": " But we know deep within our soul, the correct thing to do here is to also evaluate that workload"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1458.6200000000001,
+      "end": 1460.8600000000001,
+      "text": " and look at what access it actually needs."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1461.02,
+      "end": 1463.42,
+      "text": " So you might be able to talk to the team responsible."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1463.8400000000001,
+      "end": 1468.8200000000002,
+      "text": " You might be able to use IAM access analyzer, and you'll be able to create a really fine grain"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1468.8200000000002,
+      "end": 1470.8400000000001,
+      "text": " permission for that role, right?"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1470.84,
+      "end": 1472.34,
+      "text": " It probably only accesses one bucket."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1472.62,
+      "end": 1476.8,
+      "text": " It might only access a soap key within the bucket, and you can give it a very strict,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1476.8999999999999,
+      "end": 1478.22,
+      "text": " you know, put object policy."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1478.76,
+      "end": 1485.12,
+      "text": " And with every step you encounter, you're incrementally improving your posture, okay?"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1485.1599999999999,
+      "end": 1487.84,
+      "text": " So the scream test is going to be your friend."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1488.48,
+      "end": 1491.1399999999999,
+      "text": " You're going to have a lot of rinse and repeat on this process."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1491.26,
+      "end": 1492.24,
+      "text": " But I have done it."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1492.3,
+      "end": 1492.9399999999998,
+      "text": " It is painful."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1492.94,
+      "end": 1494.3600000000001,
+      "text": " But it can be done."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1494.52,
+      "end": 1499.8200000000002,
+      "text": " And it's definitely one of the best things you can do for your organization from a security"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1499.8200000000002,
+      "end": 1500.6000000000001,
+      "text": " standpoint."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1500.8200000000002,
+      "end": 1505.3600000000001,
+      "text": " The other aspect then is, well, what if I have a different cloud?"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1505.6000000000001,
+      "end": 1511.16,
+      "text": " And what I mean by that usually is you could have CircleCI, GitHub Actions, HashiCorp Cloud."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1511.16,
+      "end": 1516.42,
+      "text": " Often, these IAM users are created because you need access from a system that is not AWS,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1516.72,
+      "end": 1519.8000000000002,
+      "text": " where we can't rely on assuming a role or something like that."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1519.94,
+      "end": 1523.74,
+      "text": " So that was a very common source of IAM users, you know, some sort of pipeline user."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1524.28,
+      "end": 1529.0400000000002,
+      "text": " Thankfully, in the last couple of years, OIDC identity providers have solved a lot of this."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1529.04,
+      "end": 1533.62,
+      "text": " I believe there's previous episodes where they're covered, but stuff like GitHub Actions will"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1533.62,
+      "end": 1538.22,
+      "text": " now give you, you know, fine-grained access to a role to a particular repo or even to a"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1538.22,
+      "end": 1544.96,
+      "text": " particular operation in a repo, like the repo being tagged or a release being created or a"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1544.96,
+      "end": 1547.02,
+      "text": " certain branch name being pushed to."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1547.32,
+      "end": 1552.1599999999999,
+      "text": " So you can get extremely fine-grained access from GitHub Actions into AWS now as well."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1552.28,
+      "end": 1558.02,
+      "text": " So that's kind of the tried and true method to replace those cloud-to-cloud IAM users."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1558.02,
+      "end": 1562.54,
+      "text": " And I guess finally, you know, we can strive for perfection, but we're probably going to"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1562.54,
+      "end": 1564.36,
+      "text": " have a handful of IAM users when we're finished."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1564.52,
+      "end": 1565.84,
+      "text": " Could be some legacy system."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1566.34,
+      "end": 1570.5,
+      "text": " There could be a user with a customer or on a server somewhere in the wild that we don't"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1570.5,
+      "end": 1571.34,
+      "text": " control anymore."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1571.76,
+      "end": 1574.26,
+      "text": " Unfortunately, you might end up with a handful of IAM users."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1574.6,
+      "end": 1579.94,
+      "text": " What we recommend there is the SCP to block creation of new ones so we can at least plug"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1579.94,
+      "end": 1580.4,
+      "text": " the leak."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1580.52,
+      "end": 1582.12,
+      "text": " And then we can document those users."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1582.42,
+      "end": 1586.6,
+      "text": " We could import them into Terraform or CloudFormation so that we have them in infrastructure as code."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1586.6,
+      "end": 1588.8799999999999,
+      "text": " It's easy to kind of ring fence the problem."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1589.6599999999999,
+      "end": 1594.8,
+      "text": " We could introduce rotation, again, if we have access to the system where they're used."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1595.1599999999999,
+      "end": 1600.26,
+      "text": " And you could even implement, you know, event bridge notifications, AWS Config."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1600.78,
+      "end": 1606.1599999999999,
+      "text": " You can just really scrutinize those IAM users and make sure we know whenever they do something"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1606.1599999999999,
+      "end": 1606.6399999999999,
+      "text": " interesting."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1607,
+      "end": 1610.08,
+      "text": " So I think that's all I have on the topic."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1610.08,
+      "end": 1614.6,
+      "text": " It's a challenge, but I would say it's definitely worth doing."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1615,
+      "end": 1620.6,
+      "text": " It's a game changer for your security posture, particularly in AWS environments that have"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1620.6,
+      "end": 1621.8799999999999,
+      "text": " been around for a couple of years."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 1622.1399999999999,
+      "end": 1622.24,
+      "text": " Yeah."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1622.3,
+      "end": 1623.96,
+      "text": " Thank you for all these amazing suggestions."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1624.24,
+      "end": 1629.52,
+      "text": " I especially like the last one about importing the users, making sure that they're well documented,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1630,
+      "end": 1631.8799999999999,
+      "text": " creating SCPs to avoid new users."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1632.28,
+      "end": 1632.6799999999998,
+      "text": " And yeah."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1632.68,
+      "end": 1636.92,
+      "text": " Rotating credentials is something that most often, at least, is done manually."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1637.16,
+      "end": 1640.76,
+      "text": " So probably you want to have some kind of playbook where you kind of document very well"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1640.76,
+      "end": 1641.5600000000002,
+      "text": " all the steps."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1641.8200000000002,
+      "end": 1645.8400000000001,
+      "text": " At least you can do it in a repeatable way and have a process that kind of reminds yourself"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1645.8400000000001,
+      "end": 1647.04,
+      "text": " to do it often enough."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1647.38,
+      "end": 1649.7,
+      "text": " So with that, I think it's a wrap for today."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1650.0600000000002,
+      "end": 1653.9,
+      "text": " I hope that we have convinced you that IAM users are not a good practice."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1654.0800000000002,
+      "end": 1659.1000000000001,
+      "text": " I hope that we have given you enough suggestions and motivation to get started on getting rid of"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1659.1,
+      "end": 1659.3,
+      "text": " them."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1659.58,
+      "end": 1661.9599999999998,
+      "text": " And hopefully you enjoyed this episode."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1662.26,
+      "end": 1664.8999999999999,
+      "text": " So if you've done that, please give us feedback."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1665.02,
+      "end": 1668.6999999999998,
+      "text": " As always, thumbs up, share, like, subscribe, and all the usual things."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1668.9399999999998,
+      "end": 1673.5,
+      "text": " And I want to conclude with a big thank you to Connor for bringing us a fresh perspective"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1673.5,
+      "end": 1675.86,
+      "text": " and to be our new host for this episode."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1676.1399999999999,
+      "end": 1678.06,
+      "text": " So until next time, thank you very much."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1678.1399999999999,
+      "end": 1680.02,
+      "text": " And we'll see you in the next episode."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1689.1,
+      "end": 1690.1,
+      "text": " Bye."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1690.1,
+      "end": 1691.1,
+      "text": " Bye."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1691.1,
+      "end": 1692.1,
+      "text": " Bye."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1692.1,
+      "end": 1693.1,
+      "text": " Bye."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1693.1,
+      "end": 1694.1,
+      "text": " Bye."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 1694.1,
+      "end": 1695.1,
+      "text": " Bye."
+    }
+  ]
+}

--- a/src/_transcripts/134.json
+++ b/src/_transcripts/134.json
@@ -1,14 +1,14 @@
 {
   "speakers": {
-    "spk_0": "spk_0",
-    "spk_1": "spk_1"
+    "spk_0": "Luciano",
+    "spk_1": "Conor"
   },
   "segments": [
     {
       "speakerLabel": "spk_0",
       "start": 0,
       "end": 5.04,
-      "text": " Hello, friends of AWS Bites podcast, the show where we share stories and hard-heard lessons"
+      "text": " Hello, friends of AWS Bites podcast, the show where we share stories and hard-learned lessons"
     },
     {
       "speakerLabel": "spk_0",
@@ -104,7 +104,7 @@
       "speakerLabel": "spk_0",
       "start": 42.62,
       "end": 46.58,
-      "text": " My name is Luciano, and today I'm joined by Connor, our new co-host, who brings tons of"
+      "text": " My name is Luciano, and today I'm joined by Conor, our new co-host, who brings tons of"
     },
     {
       "speakerLabel": "spk_0",
@@ -128,13 +128,13 @@
       "speakerLabel": "spk_0",
       "start": 50.72,
       "end": 60.82,
-      "text": " AWS Bites is brought to you by Forteorem."
+      "text": " AWS Bites is brought to you by fourTheorem."
     },
     {
       "speakerLabel": "spk_0",
       "start": 60.98,
       "end": 65.82,
-      "text": " If you are looking for a partner to architect, develop, and modernize on AWS, give Forteorem"
+      "text": " If you are looking for a partner to architect, develop, and modernize on AWS, give fourTheorem"
     },
     {
       "speakerLabel": "spk_0",
@@ -146,7 +146,7 @@
       "speakerLabel": "spk_0",
       "start": 66.44,
       "end": 68.46000000000001,
-      "text": " Check us out at forteorem.com."
+      "text": " Check us out at fourtheorem.com."
     },
     {
       "speakerLabel": "spk_0",
@@ -158,13 +158,13 @@
       "speakerLabel": "spk_0",
       "start": 71.16,
       "end": 75.25999999999999,
-      "text": " But today, we have Connor, who brings lots of expertise and fresh perspective."
+      "text": " But today, we have Conor, who brings lots of expertise and fresh perspective."
     },
     {
       "speakerLabel": "spk_0",
       "start": 75.26,
       "end": 79.94,
-      "text": " So maybe it's a good idea to start with just Connor introducing yourself so people can"
+      "text": " So maybe it's a good idea to start with just Conor introducing yourself so people can"
     },
     {
       "speakerLabel": "spk_0",
@@ -180,12 +180,6 @@
     },
     {
       "speakerLabel": "spk_1",
-      "start": 82.94,
-      "end": 83.5,
-      "text": " Yeah."
-    },
-    {
-      "speakerLabel": "spk_1",
       "start": 83.68,
       "end": 87.24000000000001,
       "text": " Long-time listener, first-time caller, I guess, to AWS Bites."
@@ -194,7 +188,7 @@
       "speakerLabel": "spk_1",
       "start": 87.64,
       "end": 89.96000000000001,
-      "text": " So I joined Forteorem about 18 months ago."
+      "text": " So I joined fourTheorem about 18 months ago."
     },
     {
       "speakerLabel": "spk_1",
@@ -267,12 +261,6 @@
       "start": 139.38000000000002,
       "end": 140.92000000000002,
       "text": " So yeah, that's me."
-    },
-    {
-      "speakerLabel": "spk_1",
-      "start": 140.92000000000002,
-      "end": 141.20000000000002,
-      "text": " Yeah."
     },
     {
       "speakerLabel": "spk_0",
@@ -548,7 +536,7 @@
       "speakerLabel": "spk_0",
       "start": 288.3,
       "end": 290.98,
-      "text": " But I don't know, Connor, if you have anything else you would like to add."
+      "text": " But I don't know, Conor, if you have anything else you would like to add."
     },
     {
       "speakerLabel": "spk_1",
@@ -1322,7 +1310,7 @@
       "speakerLabel": "spk_1",
       "start": 765.6999999999999,
       "end": 768.14,
-      "text": " So we'd create an account for Connor and an account for Luciano."
+      "text": " So we'd create an account for Conor and an account for Luciano."
     },
     {
       "speakerLabel": "spk_1",
@@ -1340,7 +1328,7 @@
       "speakerLabel": "spk_1",
       "start": 773.14,
       "end": 777.84,
-      "text": " And when you had access to maybe dozens of accounts, we still had one Connor and one Luciano"
+      "text": " And when you had access to maybe dozens of accounts, we still had one Conor and one Luciano"
     },
     {
       "speakerLabel": "spk_1",
@@ -1382,7 +1370,7 @@
       "speakerLabel": "spk_1",
       "start": 799.66,
       "end": 806.4599999999999,
-      "text": " And that might say, the only person who can assume me is Luciano or Connor from this Bastion"
+      "text": " And that might say, the only person who can assume me is Luciano or Conor from this Bastion"
     },
     {
       "speakerLabel": "spk_1",
@@ -2177,7 +2165,7 @@
       "text": " better?"
     },
     {
-      "speakerLabel": "spk_0",
+      "speakerLabel": "spk_1",
       "start": 1302.16,
       "end": 1302.8799999999999,
       "text": " Yeah, absolutely."
@@ -2822,7 +2810,7 @@
       "speakerLabel": "spk_0",
       "start": 1668.9399999999998,
       "end": 1673.5,
-      "text": " And I want to conclude with a big thank you to Connor for bringing us a fresh perspective"
+      "text": " And I want to conclude with a big thank you to Conor for bringing us a fresh perspective"
     },
     {
       "speakerLabel": "spk_0",
@@ -2841,42 +2829,6 @@
       "start": 1678.1399999999999,
       "end": 1680.02,
       "text": " And we'll see you in the next episode."
-    },
-    {
-      "speakerLabel": "spk_0",
-      "start": 1689.1,
-      "end": 1690.1,
-      "text": " Bye."
-    },
-    {
-      "speakerLabel": "spk_0",
-      "start": 1690.1,
-      "end": 1691.1,
-      "text": " Bye."
-    },
-    {
-      "speakerLabel": "spk_0",
-      "start": 1691.1,
-      "end": 1692.1,
-      "text": " Bye."
-    },
-    {
-      "speakerLabel": "spk_0",
-      "start": 1692.1,
-      "end": 1693.1,
-      "text": " Bye."
-    },
-    {
-      "speakerLabel": "spk_0",
-      "start": 1693.1,
-      "end": 1694.1,
-      "text": " Bye."
-    },
-    {
-      "speakerLabel": "spk_0",
-      "start": 1694.1,
-      "end": 1695.1,
-      "text": " Bye."
     }
   ]
 }

--- a/src/_transcripts/134.vtt
+++ b/src/_transcripts/134.vtt
@@ -1,0 +1,1885 @@
+WEBVTT
+
+1
+00:00:00.000 --> 00:00:05.040
+Hello, friends of AWS Bites podcast, the show where we share stories and hard-learned lessons
+
+2
+00:00:05.040 --> 00:00:05.960
+from the cloud trenches.
+
+3
+00:00:06.080 --> 00:00:08.700
+Today, we are here to sound the alarm on something very serious.
+
+4
+00:00:09.100 --> 00:00:13.220
+You need to eliminate IAM users from your AWS accounts and fast.
+
+5
+00:00:13.420 --> 00:00:16.660
+Seriously, if you are still using them, it's like an incident just waiting to happen.
+
+6
+00:00:16.820 --> 00:00:20.600
+It's like handing your credit card details to a stranger online and hoping they will
+
+7
+00:00:20.600 --> 00:00:21.440
+surprise you with a gift.
+
+8
+00:00:21.600 --> 00:00:22.300
+But I'll give you a spoiler.
+
+9
+00:00:22.500 --> 00:00:24.060
+You won't like the gift that you will get.
+
+10
+00:00:24.220 --> 00:00:25.320
+So just be very careful.
+
+11
+00:00:25.560 --> 00:00:26.140
+Don't do that.
+
+12
+00:00:26.300 --> 00:00:29.540
+And we have talked already about governance and lending zone in the past.
+
+13
+00:00:29.540 --> 00:00:34.460
+But today, we want to focus specifically on why IAM users and long-lived credentials
+
+14
+00:00:34.460 --> 00:00:38.100
+are one of the biggest foot guns that exists today in AWS.
+
+15
+00:00:38.300 --> 00:00:42.000
+And hopefully, we'll also share some strategies on how you can start to get rid of them if
+
+16
+00:00:42.000 --> 00:00:42.580
+you are still using them.
+
+17
+00:00:42.620 --> 00:00:46.580
+My name is Luciano, and today I'm joined by Conor, our new co-host, who brings tons of
+
+18
+00:00:46.580 --> 00:00:48.520
+experience in managing AWS accounts.
+
+19
+00:00:48.620 --> 00:00:49.580
+So I'm really excited.
+
+20
+00:00:49.800 --> 00:00:50.720
+Let's get into it.
+
+21
+00:00:50.720 --> 00:01:00.820
+AWS Bites is brought to you by fourTheorem.
+
+22
+00:01:00.980 --> 00:01:05.820
+If you are looking for a partner to architect, develop, and modernize on AWS, give fourTheorem
+
+23
+00:01:05.820 --> 00:01:06.220
+a call.
+
+24
+00:01:06.440 --> 00:01:08.460
+Check us out at fourtheorem.com.
+
+25
+00:01:08.580 --> 00:01:10.960
+So as I said, we already covered similar topics.
+
+26
+00:01:11.160 --> 00:01:15.260
+But today, we have Conor, who brings lots of expertise and fresh perspective.
+
+27
+00:01:15.260 --> 00:01:19.940
+So maybe it's a good idea to start with just Conor introducing yourself so people can
+
+28
+00:01:19.940 --> 00:01:21.840
+know all the amazing things that you have done.
+
+29
+00:01:22.380 --> 00:01:22.500
+Sure.
+
+30
+00:01:23.680 --> 00:01:27.240
+Long-time listener, first-time caller, I guess, to AWS Bites.
+
+31
+00:01:27.640 --> 00:01:29.960
+So I joined fourTheorem about 18 months ago.
+
+32
+00:01:30.360 --> 00:01:32.580
+I'm a senior infrastructure engineer.
+
+33
+00:01:33.020 --> 00:01:36.520
+And I guess I've worked with a lot of startups over my career.
+
+34
+00:01:36.680 --> 00:01:42.520
+Very interested in the security space in AWS and infrastructure as code and all things safety
+
+35
+00:01:42.520 --> 00:01:44.380
+and security in the cloud, I guess.
+
+36
+00:01:44.380 --> 00:01:48.960
+So I've had the privilege of joining a lot of excellent teams over the years.
+
+37
+00:01:49.120 --> 00:01:54.960
+But a lot of times, I may have been the first security nerd or AWS practitioner to join the
+
+38
+00:01:54.960 --> 00:01:55.220
+team.
+
+39
+00:01:55.460 --> 00:02:01.760
+So I have often encountered very mature AWS accounts with lots of IAM users.
+
+40
+00:02:02.560 --> 00:02:07.640
+And what we want to chat about today, I guess, is there's a lot of modern techniques and tooling
+
+41
+00:02:07.640 --> 00:02:13.020
+that help us totally eliminate those IAM users, which have become a bit of a security
+
+42
+00:02:13.020 --> 00:02:18.880
+nightmare or certainly a potential rake in the grass for a lot of organizations.
+
+43
+00:02:19.380 --> 00:02:20.920
+So yeah, that's me.
+
+44
+00:02:21.260 --> 00:02:25.280
+I can only add that you are one of the people I know with the most Terraform expertise.
+
+45
+00:02:25.680 --> 00:02:29.380
+So I'm really lucky to have you as a colleague every time I have a question about Terraform.
+
+46
+00:02:29.380 --> 00:02:32.120
+So that's just to send a little bit more context.
+
+47
+00:02:32.380 --> 00:02:37.320
+But yeah, going back to IAM users, I guess one main question that people might have is
+
+48
+00:02:37.320 --> 00:02:38.940
+like, what is really the problem, right?
+
+49
+00:02:38.980 --> 00:02:41.600
+It seems like something that has been in AWS forever.
+
+50
+00:02:41.800 --> 00:02:44.360
+So why should it be a problem in the first place, right?
+
+51
+00:02:44.460 --> 00:02:47.840
+And we said it is one of the biggest foot guns that you have today.
+
+52
+00:02:47.960 --> 00:02:52.400
+And the main reason to that is that when you use IAM users, generally, you are also using
+
+53
+00:02:52.400 --> 00:02:53.420
+long-lived credentials.
+
+54
+00:02:53.420 --> 00:02:58.100
+So you go into that specific user and maybe through the web UI and you generate credentials
+
+55
+00:02:58.100 --> 00:02:58.820
+for that user.
+
+56
+00:02:59.200 --> 00:03:03.600
+And then God knows where you're going to copy-paste those credentials, store them somewhere forever,
+
+57
+00:03:03.800 --> 00:03:04.920
+maybe forget about them.
+
+58
+00:03:05.340 --> 00:03:07.940
+And I don't know, they can end up in development machines.
+
+59
+00:03:07.940 --> 00:03:09.200
+They can end up in servers.
+
+60
+00:03:09.320 --> 00:03:12.680
+They can end up inside applications that somehow need to interact with AWS.
+
+61
+00:03:13.160 --> 00:03:15.980
+And the problem with that is that they are generally clear text.
+
+62
+00:03:16.360 --> 00:03:19.700
+So easy to exploit or exfiltrate or copy-paste.
+
+63
+00:03:20.020 --> 00:03:23.080
+And the other problem is that generally they are very broadly scoped.
+
+64
+00:03:23.080 --> 00:03:25.460
+So you can have permissions to do lots of things.
+
+65
+00:03:25.460 --> 00:03:29.780
+Even if originally you didn't intend to do all these different things, maybe it was convenient
+
+66
+00:03:29.780 --> 00:03:33.220
+to just give this particular user lots of open permissions.
+
+67
+00:03:33.680 --> 00:03:37.420
+And then whoever has access to the credentials inherits all of these permissions.
+
+68
+00:03:37.780 --> 00:03:42.280
+So imagine, yeah, you might end up with somebody just spinning up the most expensive EC2 instance
+
+69
+00:03:42.280 --> 00:03:45.160
+just because that particular user has permissions to do that.
+
+70
+00:03:45.340 --> 00:03:48.240
+And the other problem is that those credentials get rarely rotated.
+
+71
+00:03:48.620 --> 00:03:51.620
+There are ways that you can rotate the credentials, but there's generally something that people
+
+72
+00:03:51.620 --> 00:03:52.660
+don't bother doing.
+
+73
+00:03:52.660 --> 00:03:57.420
+And I personally have seen, it's funny that you can go to the web UI and see how long
+
+74
+00:03:57.420 --> 00:03:58.700
+those credentials existed.
+
+75
+00:03:59.040 --> 00:04:02.620
+Like, it's not rare to see like these credentials existed for like 2000 days.
+
+76
+00:04:02.760 --> 00:04:07.500
+And yeah, you can think of how many things could have gone wrong in so much time.
+
+77
+00:04:07.500 --> 00:04:11.880
+Like how many people could have had opportunities to take these credentials and use them to do
+
+78
+00:04:11.880 --> 00:04:12.220
+something.
+
+79
+00:04:12.220 --> 00:04:17.260
+So the other interesting use case that we have seen a lot is that if you create IAM users
+
+80
+00:04:17.260 --> 00:04:21.040
+for, I don't know, developers in your company, people will come and go in the company.
+
+81
+00:04:21.280 --> 00:04:25.340
+And sometimes you don't have a very strict process for offboarding people from your AWS
+
+82
+00:04:25.340 --> 00:04:25.800
+accounts.
+
+83
+00:04:26.220 --> 00:04:32.100
+So I know of people that were able to access accounts in AWS from not their first company,
+
+84
+00:04:32.100 --> 00:04:35.880
+but like two previous companies that they were working before, like years before.
+
+85
+00:04:35.880 --> 00:04:40.180
+And still their credentials were totally valid and they could see everything in the account
+
+86
+00:04:40.180 --> 00:04:43.880
+and do all kinds of actions that they could do as developers, even though they were not
+
+87
+00:04:43.880 --> 00:04:45.340
+employed anymore in that company.
+
+88
+00:04:45.580 --> 00:04:48.060
+So just be aware that these are just some of the risks.
+
+89
+00:04:48.300 --> 00:04:50.980
+But I don't know, Conor, if you have anything else you would like to add.
+
+90
+00:04:50.980 --> 00:04:54.580
+Yeah, I guess it is one of those difficult challenges.
+
+91
+00:04:55.580 --> 00:05:01.780
+You know, a lot of my history was in IT and onboarding and offboarding people from teams.
+
+92
+00:05:02.100 --> 00:05:09.160
+So you tend to bias towards single sign on and role based access control and credentials
+
+93
+00:05:09.160 --> 00:05:13.440
+that you can expire or at least reason about their status.
+
+94
+00:05:13.720 --> 00:05:20.500
+And like you mentioned, IAM users are incredibly challenging to keep on top of, especially in larger
+
+95
+00:05:20.500 --> 00:05:21.460
+organizations.
+
+96
+00:05:21.460 --> 00:05:27.360
+So just to add to your war stories there, like I've seen, I've seen it all, I guess, you
+
+97
+00:05:27.360 --> 00:05:33.100
+know, that the worst is when you find the root account that has an access key and secret
+
+98
+00:05:33.100 --> 00:05:35.980
+access key generated and it's being used in a pipeline.
+
+99
+00:05:35.980 --> 00:05:43.860
+But I've always seen, you know, front end engineer Bob has a large team and they're great
+
+100
+00:05:43.860 --> 00:05:46.400
+and they're tenacious about getting work done.
+
+101
+00:05:46.400 --> 00:05:52.720
+But eventually, you know, Bob moves on and suddenly all of the other front end engineers
+
+102
+00:05:52.720 --> 00:05:54.660
+development environments stop working.
+
+103
+00:05:54.820 --> 00:05:59.360
+It's typically because Bob has been really helpful and, you know, shared his IAM access
+
+104
+00:05:59.360 --> 00:06:02.660
+keys with the team, maybe check them into that repo for that app.
+
+105
+00:06:03.060 --> 00:06:08.940
+So very difficult to manage that as a, you know, a central cloud team or a practitioner that's
+
+106
+00:06:08.940 --> 00:06:10.860
+trying to keep on top of the AWS environment.
+
+107
+00:06:10.860 --> 00:06:14.960
+So I guess it's not usually somebody's fault.
+
+108
+00:06:15.120 --> 00:06:20.300
+You know, it's up to the platform team or the security team to try and put the correct
+
+109
+00:06:20.300 --> 00:06:24.060
+guardrails in place so that it's easy to do the right thing and very difficult to do the
+
+110
+00:06:24.060 --> 00:06:24.540
+wrong thing.
+
+111
+00:06:24.780 --> 00:06:28.440
+And I guess later on in the episode, we're going to get into a lot of the modern techniques
+
+112
+00:06:28.440 --> 00:06:32.640
+for doing things the right way that just make it much more difficult to create these
+
+113
+00:06:32.640 --> 00:06:34.260
+kind of edge cases in the first place.
+
+114
+00:06:34.700 --> 00:06:37.740
+But yeah, IAM users will end up on developer machines.
+
+115
+00:06:37.740 --> 00:06:40.840
+They'll end up in Dropbox, Google Drive, Slack messages.
+
+116
+00:06:41.460 --> 00:06:46.200
+You know, you'll have users that were intended for human access that end up in pipelines or
+
+117
+00:06:46.200 --> 00:06:47.160
+production systems.
+
+118
+00:06:47.700 --> 00:06:54.080
+So I guess our goal today is to tell everybody that there is a better way and you can get
+
+119
+00:06:54.080 --> 00:06:56.040
+to the point that you have no IAM users at all.
+
+120
+00:06:56.320 --> 00:07:00.040
+Depending on your environment, that's going to be a simple or very arduous journey.
+
+121
+00:07:00.260 --> 00:07:01.980
+But I guess we want to help you to get there.
+
+122
+00:07:02.280 --> 00:07:06.580
+So I guess the reason you end up with these in the first place is because somebody wants to
+
+123
+00:07:06.580 --> 00:07:09.380
+do programmatic access to AWS, right?
+
+124
+00:07:09.440 --> 00:07:15.860
+Whether it's from a pipeline that's running on an EC2 instance or ECS Fargate, or more
+
+125
+00:07:15.860 --> 00:07:21.280
+commonly, the development flow where you want to interact with S3 or CloudFormation or you
+
+126
+00:07:21.280 --> 00:07:23.680
+want to run CDK deploy from your laptop.
+
+127
+00:07:23.860 --> 00:07:26.280
+You need programmatic access to the AWS account.
+
+128
+00:07:26.580 --> 00:07:31.140
+All requests to AWS have to be signed with the SIG V4 algorithm.
+
+129
+00:07:31.140 --> 00:07:35.440
+So I think what we want to focus on initially is how does it work?
+
+130
+00:07:35.520 --> 00:07:42.400
+If I run AWS S3 LS from the CLI, what goes on under the hood there in the SDK for it to
+
+131
+00:07:42.400 --> 00:07:46.440
+try and find credentials and authenticate itself against AWS APIs?
+
+132
+00:07:47.140 --> 00:07:50.060
+Do you want to chat about your experience with that, Luciano?
+
+133
+00:07:50.380 --> 00:07:53.040
+Yeah, that's a very interesting topic.
+
+134
+00:07:53.400 --> 00:07:55.520
+I actually really like that kind of stuff.
+
+135
+00:07:55.580 --> 00:07:57.140
+Like you mentioned, the SIG V4 algorithm.
+
+136
+00:07:57.140 --> 00:08:01.360
+We're not going to go into detail on that one today, but we'll post a link in the show
+
+137
+00:08:01.360 --> 00:08:02.140
+notes if you're curious.
+
+138
+00:08:02.460 --> 00:08:07.240
+What we want to focus a bit more on is that there needs to be a process for if you're using
+
+139
+00:08:07.240 --> 00:08:12.600
+the SDK or the CLI to locate credentials in that execution environment.
+
+140
+00:08:12.880 --> 00:08:18.440
+And there are specific pages that you can find in the AWS docs, depending if you're using a
+
+141
+00:08:18.440 --> 00:08:23.380
+specific SDK, like for instance, the JavaScript one, there is a page that details exactly all the
+
+142
+00:08:23.380 --> 00:08:28.460
+steps that are performed to try to find a viable set of credentials when you create a client
+
+143
+00:08:28.460 --> 00:08:29.240
+using the SDK.
+
+144
+00:08:29.660 --> 00:08:33.660
+And there is a similar page for the CLI, so we'll make sure to share the links as well.
+
+145
+00:08:33.780 --> 00:08:36.100
+But just to summarize, what are the different steps?
+
+146
+00:08:36.220 --> 00:08:42.160
+So you can have an idea of all the different things that can provide credentials to a given
+
+147
+00:08:42.160 --> 00:08:42.620
+environment.
+
+148
+00:08:42.820 --> 00:08:47.620
+So the first thing is that as you create a client, you are effectively instantiating a
+
+149
+00:08:47.620 --> 00:08:47.920
+class.
+
+150
+00:08:48.240 --> 00:08:51.840
+Let's imagine in JavaScript, you say, I don't know, new S3 client, something like that.
+
+151
+00:08:51.840 --> 00:08:56.000
+You can provide options there as the constructor of that function call.
+
+152
+00:08:56.300 --> 00:09:01.440
+And some of the options there are specifically put in place so that you can provide inline
+
+153
+00:09:01.440 --> 00:09:01.880
+credentials.
+
+154
+00:09:02.120 --> 00:09:06.240
+So if you do that, this is the first thing that the client is going to look for.
+
+155
+00:09:06.400 --> 00:09:09.180
+And if you provide the credentials there, those credentials will be used.
+
+156
+00:09:09.340 --> 00:09:11.420
+But those credentials there are not mandatory.
+
+157
+00:09:11.640 --> 00:09:13.160
+So what happens if you don't provide them?
+
+158
+00:09:13.280 --> 00:09:18.320
+And the next step is that if credentials are not there in the constructor options, the client
+
+159
+00:09:18.320 --> 00:09:20.380
+is going to look for specific environment variables.
+
+160
+00:09:20.380 --> 00:09:25.020
+And I'm sure you have seen the AWS secret key and that kind of environment variables.
+
+161
+00:09:25.300 --> 00:09:27.500
+So this is the next thing that the client is going to look for.
+
+162
+00:09:27.580 --> 00:09:31.680
+So if in the current execution environment, you have those variables set, those will be
+
+163
+00:09:31.680 --> 00:09:33.860
+used for your client to interact with AWS.
+
+164
+00:09:34.160 --> 00:09:37.280
+Then the next step is that if you don't have those environment variables, then it's going
+
+165
+00:09:37.280 --> 00:09:38.740
+to look for shared credentials files.
+
+166
+00:09:39.420 --> 00:09:45.440
+You can imagine similar to when you configure your CLI that you might have credentials files that
+
+167
+00:09:45.440 --> 00:09:45.680
+way.
+
+168
+00:09:45.680 --> 00:09:49.900
+And then you can have in specific environments, for instance, if you're running your code in
+
+169
+00:09:49.900 --> 00:09:54.780
+ECS, ECS has mechanisms to provide credentials through, for instance, roles.
+
+170
+00:09:54.980 --> 00:09:56.240
+You can have short-lived credentials.
+
+171
+00:09:56.600 --> 00:10:01.460
+So if you have done all of that, configure correctly, the SDK can actually load these credentials.
+
+172
+00:10:01.900 --> 00:10:02.960
+So that would be another step.
+
+173
+00:10:02.960 --> 00:10:04.700
+And we can keep going.
+
+174
+00:10:04.840 --> 00:10:05.720
+There are other steps.
+
+175
+00:10:06.180 --> 00:10:11.520
+You can use credential processes, which is just a mechanism where you can have custom ways
+
+176
+00:10:11.520 --> 00:10:13.800
+to say, I can call a specific process.
+
+177
+00:10:13.980 --> 00:10:18.240
+And that process is responsible for somehow fetching credentials that I can use.
+
+178
+00:10:18.560 --> 00:10:21.740
+And this is generally when you want to integrate with, I don't know, third-party tools.
+
+179
+00:10:22.260 --> 00:10:26.680
+Maybe you have some kind of vault or secret manager and you store configuration there.
+
+180
+00:10:26.680 --> 00:10:32.500
+That configuration can contain your AWS credentials and you can create that mechanism to load credentials
+
+181
+00:10:32.500 --> 00:10:33.380
+from a custom place.
+
+182
+00:10:33.640 --> 00:10:39.480
+And then finally, another example is if you're using EC2 as a concept of instance metadata.
+
+183
+00:10:40.080 --> 00:10:44.460
+So that's basically a mechanism where if you provide a role to an EC2 instance, that role
+
+184
+00:10:44.460 --> 00:10:46.700
+can have effectively permissions attached to it.
+
+185
+00:10:46.780 --> 00:10:52.160
+And the way that your client inside that EC2 inherits those permissions is by accessing this
+
+186
+00:10:52.160 --> 00:10:57.020
+metadata server, let's call it, it's kind of a local server that if you call it through
+
+187
+00:10:57.020 --> 00:11:01.720
+an HTTP endpoint, it's going to give you temporary credentials that are scoped specifically with
+
+188
+00:11:01.720 --> 00:11:03.180
+the role attached to the instance.
+
+189
+00:11:03.520 --> 00:11:08.260
+And I guess some of these ideas are better than others because they will give you shorter
+
+190
+00:11:08.260 --> 00:11:09.480
+term credentials.
+
+191
+00:11:09.900 --> 00:11:15.220
+But because the most common or at least historically the most used option is just copy-paste some
+
+192
+00:11:15.220 --> 00:11:19.980
+credentials into the environment, people tend to do IAM users, copy-paste credentials and
+
+193
+00:11:19.980 --> 00:11:24.700
+use them even for programmatic access on a kind of server process or something that should
+
+194
+00:11:24.700 --> 00:11:26.420
+have been managed differently.
+
+195
+00:11:26.780 --> 00:11:31.340
+So that's, I guess, probably trying to shed some light on the fact that, yeah, there are
+
+196
+00:11:31.340 --> 00:11:34.760
+different ways to provide credentials and it's kind of a step-by-step.
+
+197
+00:11:34.880 --> 00:11:37.520
+If the first step fails, it's going to look for the second step and so on.
+
+198
+00:11:37.540 --> 00:11:41.780
+So it's important to also understand what is the priority of what the SDK or the CLI is
+
+199
+00:11:41.780 --> 00:11:42.260
+looking for.
+
+200
+00:11:42.620 --> 00:11:46.880
+So again, link to the links in the description if you're curious to find out exactly from the
+
+201
+00:11:46.880 --> 00:11:48.180
+docs what are the different steps.
+
+202
+00:11:48.180 --> 00:11:53.860
+So the question now could be, okay, I kind of get the point that I shouldn't use IAM users,
+
+203
+00:11:54.040 --> 00:11:58.640
+but if I am, what are some of the mitigation strategies that I can start to use today?
+
+204
+00:11:58.840 --> 00:11:58.960
+Yeah.
+
+205
+00:11:59.040 --> 00:12:04.360
+So I guess the community kind of arrived at a lot of interesting patterns.
+
+206
+00:12:05.160 --> 00:12:09.960
+I was trying to find the article this morning, but it seems to be removed probably because
+
+207
+00:12:09.960 --> 00:12:11.540
+there's better strategies available now.
+
+208
+00:12:11.620 --> 00:12:14.220
+But I think it was Coinbase back in 2017.
+
+209
+00:12:14.220 --> 00:12:18.920
+I had a great article on their engineering blog about the Bastion IAM account.
+
+210
+00:12:19.300 --> 00:12:22.820
+So that might be a more typical pattern for an SSH jump host or something.
+
+211
+00:12:22.940 --> 00:12:25.900
+People would usually mention Bastion in that context, I guess.
+
+212
+00:12:26.020 --> 00:12:31.420
+But what Coinbase had established, and it was a pattern that I saw used a lot across the industry,
+
+213
+00:12:31.760 --> 00:12:34.100
+was they would elect an account.
+
+214
+00:12:34.260 --> 00:12:35.920
+Let's call it the Bastion account.
+
+215
+00:12:36.140 --> 00:12:38.640
+Maybe it was the management account of the organization.
+
+216
+00:12:38.640 --> 00:12:39.600
+It didn't really matter.
+
+217
+00:12:39.880 --> 00:12:45.420
+And what you could do is you would create your concrete IAM users in that account.
+
+218
+00:12:45.700 --> 00:12:48.140
+So we'd create an account for Conor and an account for Luciano.
+
+219
+00:12:48.380 --> 00:12:50.100
+Straight away, that was a big win, right?
+
+220
+00:12:50.140 --> 00:12:52.860
+Because you were at least centralizing the IAM user.
+
+221
+00:12:53.140 --> 00:12:57.840
+And when you had access to maybe dozens of accounts, we still had one Conor and one Luciano
+
+222
+00:12:57.840 --> 00:12:59.160
+instead of dozens of each.
+
+223
+00:12:59.420 --> 00:13:05.160
+And so the pattern that was established there was to try and enable role-based access control.
+
+224
+00:13:05.160 --> 00:13:10.920
+So typically then you'd create maybe an admin or a power user or a view-only role in each
+
+225
+00:13:10.920 --> 00:13:12.720
+of the accounts that we operate in.
+
+226
+00:13:12.960 --> 00:13:18.360
+And then what they would do is they would set strict conditions in the trust relationships
+
+227
+00:13:18.360 --> 00:13:19.460
+of those roles.
+
+228
+00:13:19.660 --> 00:13:26.460
+And that might say, the only person who can assume me is Luciano or Conor from this Bastion
+
+229
+00:13:26.460 --> 00:13:26.820
+account.
+
+230
+00:13:26.980 --> 00:13:33.300
+And you could attach other STS conditions like a multi-factor token must be present and must
+
+231
+00:13:33.300 --> 00:13:33.820
+be valid.
+
+232
+00:13:33.820 --> 00:13:39.360
+So that was one of the ways that practitioners tried to create this kind of role-based access
+
+233
+00:13:39.360 --> 00:13:42.260
+control, centralize it through a single IAM user.
+
+234
+00:13:42.780 --> 00:13:49.680
+And at least then we had our sane access pattern, easy to onboard users, easy revocation.
+
+235
+00:13:50.160 --> 00:13:55.060
+So that was a pattern that was kind of a battle-tested pattern.
+
+236
+00:13:55.360 --> 00:14:00.180
+And then on the client side, I guess, or on your developer machine, you've still got that
+
+237
+00:14:00.180 --> 00:14:01.980
+plain text long-lived credential.
+
+238
+00:14:01.980 --> 00:14:04.220
+Okay, so how do we protect that?
+
+239
+00:14:04.460 --> 00:14:10.180
+So another excellent tool that people might recognize was by 99designs, and that was a
+
+240
+00:14:10.180 --> 00:14:11.480
+tool called AWS Vault.
+
+241
+00:14:11.720 --> 00:14:16.300
+And I guess the innovation there was they allowed you to use whatever keychain you had on your
+
+242
+00:14:16.300 --> 00:14:19.720
+system, whether it was Linux or even the macOS keychain.
+
+243
+00:14:19.720 --> 00:14:25.160
+It would essentially escrow the access key and secret access key in the keychain.
+
+244
+00:14:25.160 --> 00:14:30.960
+And then instead of directly exposing those credentials to the SDK or the CLI, like we just
+
+245
+00:14:30.960 --> 00:14:37.260
+spoke about, it would either make some sort of STS get temporary credentials API call, or
+
+246
+00:14:37.260 --> 00:14:43.840
+you would perform the STS assume role operation to assume that concrete role in the target account,
+
+247
+00:14:44.060 --> 00:14:44.180
+right?
+
+248
+00:14:44.180 --> 00:14:46.660
+Let's say the admin role in my development account.
+
+249
+00:14:46.660 --> 00:14:50.900
+And so now you had a scenario where your access keys were protected in the keychain.
+
+250
+00:14:51.020 --> 00:14:56.440
+You were only ever retrieving temporary credentials and exposing them to the runtime, whether it
+
+251
+00:14:56.440 --> 00:15:01.320
+was the SDK or the CLI, where a lot of these tools actually injected the environment variables
+
+252
+00:15:01.320 --> 00:15:01.980
+into the shell.
+
+253
+00:15:02.140 --> 00:15:03.220
+Multiple reasons for that.
+
+254
+00:15:03.420 --> 00:15:07.040
+One reason is because all of the SDKs understand that, as we just covered.
+
+255
+00:15:07.040 --> 00:15:10.920
+But also it has one of the highest precedences in the credential chain.
+
+256
+00:15:11.280 --> 00:15:15.220
+So more often than not, that's the behavior you wanted when you were running locally.
+
+257
+00:15:15.540 --> 00:15:19.520
+So that was kind of the mitigation strategy that the community arrived at.
+
+258
+00:15:19.580 --> 00:15:20.980
+It was a very common pattern.
+
+259
+00:15:21.520 --> 00:15:27.040
+And I guess I'm showing my bias here where I've always worked at smaller startups and organizations.
+
+260
+00:15:27.660 --> 00:15:34.680
+Obviously, at larger enterprises, you'd have your SAML identity provider, which would provide
+
+261
+00:15:34.680 --> 00:15:36.820
+similar entry point to the system.
+
+262
+00:15:37.000 --> 00:15:39.860
+You would still assume roles in target accounts.
+
+263
+00:15:40.280 --> 00:15:42.520
+So that's one way it worked.
+
+264
+00:15:42.600 --> 00:15:45.340
+And you can still operate that methodology.
+
+265
+00:15:45.620 --> 00:15:47.160
+It has a good few moving parts.
+
+266
+00:15:47.160 --> 00:15:51.260
+You need to really understand trust relationships and multi-account strategy.
+
+267
+00:15:51.260 --> 00:15:55.400
+And you've got to have all your infrastructure's code tooling in place to make that a feasible
+
+268
+00:15:55.400 --> 00:15:55.840
+pattern.
+
+269
+00:15:56.300 --> 00:15:59.140
+But there are modern alternatives today.
+
+270
+00:15:59.700 --> 00:16:01.140
+Finally, spoiler alert.
+
+271
+00:16:01.140 --> 00:16:04.820
+I'm really curious to learn what those alternatives looks like.
+
+272
+00:16:05.140 --> 00:16:10.920
+Because yeah, I'm sure that there are more scalable ways today to deal with, especially if you start
+
+273
+00:16:10.920 --> 00:16:16.280
+to have multiple accounts, lots of potential users, different kinds of access levels that you need
+
+274
+00:16:16.280 --> 00:16:16.740
+to ensure.
+
+275
+00:16:16.980 --> 00:16:19.940
+And you might have lots of people coming and going in the organization as well.
+
+276
+00:16:20.120 --> 00:16:25.340
+So yes, what are those better ways to deal with user access in general and permissions?
+
+277
+00:16:31.060 --> 00:16:33.640
+Yeah, so I think there's been previous episodes on creating a landing zone and then some of the infrastructure's code tooling around that.
+
+278
+00:16:33.980 --> 00:16:40.800
+But a core component of all of those modern landing zone setups is AWS IAM Identity Center
+
+279
+00:16:40.800 --> 00:16:44.920
+and more so its integration with AWS organizations.
+
+280
+00:16:45.560 --> 00:16:51.960
+So what the Identity Center service lets you do is essentially implement the pattern we spoke
+
+281
+00:16:51.960 --> 00:16:52.260
+about.
+
+282
+00:16:52.260 --> 00:16:59.580
+So Identity Center has the concept of permission sets and permission sets are almost like a
+
+283
+00:16:59.580 --> 00:17:03.660
+wrapper for a role and then it can have targets.
+
+284
+00:17:03.940 --> 00:17:07.340
+So the target could be another AWS account or an organizational unit.
+
+285
+00:17:07.660 --> 00:17:09.740
+But essentially, we now have single sign-on.
+
+286
+00:17:09.980 --> 00:17:12.800
+Okay, Identity Center lets us create an individual identity.
+
+287
+00:17:13.200 --> 00:17:16.180
+You can use Identity Center's built-in Identity Store.
+
+288
+00:17:16.420 --> 00:17:17.440
+It's a great way to start.
+
+289
+00:17:17.440 --> 00:17:22.760
+If you're a small organization, you may not necessarily have an IDP, Azure or AD.
+
+290
+00:17:23.380 --> 00:17:29.620
+And if you just want a sane way to manage users into your AWS organization, you can use the
+
+291
+00:17:29.620 --> 00:17:30.620
+built-in Identity Store.
+
+292
+00:17:30.960 --> 00:17:34.960
+So you then have your kind of standard, you know, groups.
+
+293
+00:17:35.220 --> 00:17:40.100
+You could have a group for certain application teams, security group, platform team.
+
+294
+00:17:40.100 --> 00:17:43.320
+And you can map the groups and permission sets to accounts.
+
+295
+00:17:43.640 --> 00:17:48.020
+And then Identity Center and its integration with organizations does the rest of the heavy
+
+296
+00:17:48.020 --> 00:17:48.740
+lifting for you.
+
+297
+00:17:49.060 --> 00:17:54.780
+So if you have 10 accounts or 200 accounts, the admin role will be created automatically
+
+298
+00:17:54.780 --> 00:17:56.240
+by the permission set.
+
+299
+00:17:56.380 --> 00:17:59.280
+And then the appropriate users will be able to access it.
+
+300
+00:17:59.540 --> 00:17:59.660
+Okay.
+
+301
+00:17:59.660 --> 00:18:06.040
+So Identity Center really does all of the heavy lifting for you here as regards access to a
+
+302
+00:18:06.040 --> 00:18:07.920
+large AWS estate.
+
+303
+00:18:08.320 --> 00:18:14.340
+So the other option you have, which is convenient then, is that you can integrate most identity
+
+304
+00:18:14.340 --> 00:18:14.840
+providers.
+
+305
+00:18:15.140 --> 00:18:15.240
+Okay.
+
+306
+00:18:15.300 --> 00:18:17.580
+So at 4th Erem, we have Google Workspace integrated.
+
+307
+00:18:18.040 --> 00:18:23.880
+You can have manual user management, or you can even use something like Skim to get full
+
+308
+00:18:23.880 --> 00:18:29.220
+automated user just-in-time provisioning into the Identity Center.
+
+309
+00:18:29.220 --> 00:18:34.040
+So it's quite flexible and, you know, nice to be able to integrate it with an existing
+
+310
+00:18:34.040 --> 00:18:35.440
+identity provider.
+
+311
+00:18:35.940 --> 00:18:41.360
+So that then gives you a lovely, you know, SSO landing page that you might be familiar with,
+
+312
+00:18:41.500 --> 00:18:45.820
+and it'll present all of the AWS accounts and all of the roles that you have access to.
+
+313
+00:18:46.080 --> 00:18:50.300
+So it solves the console access problem quite well.
+
+314
+00:18:50.460 --> 00:18:55.780
+And then I guess, you know, the next step is getting your programmatic access.
+
+315
+00:18:55.780 --> 00:19:01.100
+So one thing that the Identity Center portal will let you do is grab temporary credentials
+
+316
+00:19:01.100 --> 00:19:04.300
+in the context of any role that you have access to.
+
+317
+00:19:04.560 --> 00:19:10.080
+So it's like the Identity Center console has essentially performed the, you know, STS assume
+
+318
+00:19:10.080 --> 00:19:13.140
+role or assume role with web identity operation for you.
+
+319
+00:19:13.140 --> 00:19:17.380
+And it's going to give you back an access key, a secret key, and a session token.
+
+320
+00:19:17.840 --> 00:19:23.280
+And if you want, you can just paste that in a shell or, you know, configure it in an AWS
+
+321
+00:19:23.280 --> 00:19:25.880
+credentials file, and you have your programmatic access.
+
+322
+00:19:26.200 --> 00:19:32.020
+Now, that is fine for, you know, maybe a tiny investigation or access to an account you don't
+
+323
+00:19:32.020 --> 00:19:32.860
+often use.
+
+324
+00:19:32.980 --> 00:19:37.760
+But the tool that we recommend to a lot of customers and we use internally ourselves is
+
+325
+00:19:37.760 --> 00:19:39.800
+a tool called Granted by CommonFate.
+
+326
+00:19:39.800 --> 00:19:44.460
+And the really nice thing about that tool is that you sign in, you perform the single sign-on
+
+327
+00:19:44.460 --> 00:19:48.440
+flow, and it's able to enumerate all of the accounts and roles you have access to.
+
+328
+00:19:48.580 --> 00:19:50.900
+It's able to automatically generate the config file.
+
+329
+00:19:51.340 --> 00:19:56.420
+And now you have this tool that you can run in your shell, and it can inject credentials
+
+330
+00:19:56.420 --> 00:19:59.840
+into the shell for any role in any account that you have access to.
+
+331
+00:20:00.000 --> 00:20:04.040
+So we find it, you know, a really great way to access accounts.
+
+332
+00:20:04.200 --> 00:20:06.460
+You're only ever getting back a temporary credential.
+
+333
+00:20:06.460 --> 00:20:12.400
+And it just, in an environment where you have lots of accounts, which we often encourage,
+
+334
+00:20:12.580 --> 00:20:16.860
+it just makes the, you know, the user experience really nice.
+
+335
+00:20:17.240 --> 00:20:19.300
+So what else did we want to chat about there?
+
+336
+00:20:19.540 --> 00:20:22.780
+So when you, if you do that, like this is what we think great looks like, I guess.
+
+337
+00:20:22.840 --> 00:20:27.200
+It's a lot easier in a greenfields environment to create this.
+
+338
+00:20:27.340 --> 00:20:31.840
+But we would then recommend, you know, creating an SCP policy that blocks the creation of IAM
+
+339
+00:20:31.840 --> 00:20:32.240
+users.
+
+340
+00:20:32.240 --> 00:20:36.600
+That's a common security best practice now, I guess, because once you've gotten to this
+
+341
+00:20:36.600 --> 00:20:39.060
+point, you don't want people to be able to go off piste.
+
+342
+00:20:39.220 --> 00:20:41.700
+You know, you don't want them to be able to do the bad thing.
+
+343
+00:20:41.880 --> 00:20:44.980
+Like we said, we want to make the good thing easy.
+
+344
+00:20:44.980 --> 00:20:47.600
+So we can just block the creation of IAM users.
+
+345
+00:20:48.080 --> 00:20:52.840
+Now you've got to use your single point of entry into the AWS organization to do what you
+
+346
+00:20:52.840 --> 00:20:53.600
+wanted to do.
+
+347
+00:20:53.600 --> 00:20:56.220
+Yeah, that sounds easy.
+
+348
+00:20:56.500 --> 00:21:00.660
+Again, when you are starting from scratch and you have total freedom, so you can set up
+
+349
+00:21:00.660 --> 00:21:03.660
+things in a way that looks modern and good from scratch.
+
+350
+00:21:03.660 --> 00:21:08.060
+But I would imagine that if you already have, I'm just going to say quite a legacy setup,
+
+351
+00:21:08.300 --> 00:21:11.940
+maybe with lots of stuff running there, you have been using it for years.
+
+352
+00:21:12.200 --> 00:21:14.640
+Like how do you start to enforce this kind of things?
+
+353
+00:21:14.700 --> 00:21:18.760
+I'm sure that there are cases where you cannot just get read from one day to the next one of
+
+354
+00:21:18.760 --> 00:21:24.240
+all IAM users, you need to, I don't know, probably take a few shortcuts or a few half
+
+355
+00:21:24.240 --> 00:21:26.980
+baked solutions that maybe are still better than nothing.
+
+356
+00:21:27.120 --> 00:21:31.240
+But yeah, you're probably incrementally going to get to a great place to be, but it's not
+
+357
+00:21:31.240 --> 00:21:33.340
+going to happen from like one day to the next.
+
+358
+00:21:33.720 --> 00:21:37.940
+So do you have any recommendations for people that might be more in this camp where it's not
+
+359
+00:21:37.940 --> 00:21:41.640
+going to be easy to change things, but they can still have opportunities to make things
+
+360
+00:21:41.640 --> 00:21:41.920
+better?
+
+361
+00:21:42.160 --> 00:21:42.880
+Yeah, absolutely.
+
+362
+00:21:43.080 --> 00:21:48.660
+And it is a thankless job sometimes, you know, to say, look, we've got
+
+363
+00:21:48.660 --> 00:21:50.520
+a glaring security issue here.
+
+364
+00:21:50.660 --> 00:21:51.780
+We want to pay it down.
+
+365
+00:21:52.040 --> 00:21:56.480
+So I think it's just important to have buy-in from the team and the organization, you know,
+
+366
+00:21:56.640 --> 00:22:01.880
+get it on the Kanban board, get it on the backlog and start to approach it systematically
+
+367
+00:22:01.880 --> 00:22:03.460
+because it is worth doing.
+
+368
+00:22:03.820 --> 00:22:08.240
+You're closing off one of the biggest attack vectors you have in a modern cloud environment,
+
+369
+00:22:08.340 --> 00:22:08.680
+I guess.
+
+370
+00:22:08.980 --> 00:22:10.600
+So how do you start, right?
+
+371
+00:22:10.660 --> 00:22:14.940
+The two problems we really usually have to solve is like the human access problem, which
+
+372
+00:22:14.940 --> 00:22:17.780
+tends to be simpler, and then the machine access problem.
+
+373
+00:22:17.780 --> 00:22:22.600
+Okay, like we spoke about in the intro, you're probably going to have a smattering of IAM
+
+374
+00:22:22.600 --> 00:22:23.900
+users that represent humans.
+
+375
+00:22:24.020 --> 00:22:25.720
+You might have ones that represent machines.
+
+376
+00:22:25.720 --> 00:22:29.260
+And if you're really unlucky, you're going to have the ones that were intended for humans
+
+377
+00:22:29.260 --> 00:22:30.980
+that are now being used on machines.
+
+378
+00:22:31.280 --> 00:22:32.820
+So how do we approach it?
+
+379
+00:22:33.020 --> 00:22:36.180
+The IAM credential report is super helpful.
+
+380
+00:22:36.320 --> 00:22:37.760
+We'll put a link to that in the show notes.
+
+381
+00:22:37.880 --> 00:22:41.260
+You can generate this using the CLI or from the IAM console.
+
+382
+00:22:41.260 --> 00:22:45.240
+That will give you a CSV export, which is a great place to start.
+
+383
+00:22:45.460 --> 00:22:51.860
+You know, you can sort it by access key age, or you can start to examine some of the policies
+
+384
+00:22:51.860 --> 00:22:53.260
+that are attached to the users.
+
+385
+00:22:53.680 --> 00:22:59.380
+And you can decide to organize them by danger, which sometimes makes sense, right?
+
+386
+00:22:59.500 --> 00:23:02.440
+Now, often that first pass will be a big win.
+
+387
+00:23:02.640 --> 00:23:05.760
+You're going to find people that have left the company months ago or years ago.
+
+388
+00:23:05.760 --> 00:23:09.100
+You're going to find access keys that haven't been used in some window.
+
+389
+00:23:09.500 --> 00:23:13.620
+You're going to find machine users that are for services you no longer operate.
+
+390
+00:23:14.080 --> 00:23:17.920
+And like very quickly, you might be able to shed half of the IAM users.
+
+391
+00:23:18.260 --> 00:23:18.440
+All right.
+
+392
+00:23:18.600 --> 00:23:24.640
+Now, I would also recommend implementing identity center permission sets on board yourself and
+
+393
+00:23:24.640 --> 00:23:27.700
+maybe other people on the platform team or the security team.
+
+394
+00:23:28.040 --> 00:23:32.920
+Start to kick the tires on that and introduce it for a trusted group at the organization.
+
+395
+00:23:32.920 --> 00:23:39.120
+And then you can start to reimplement your role-based access control in identity center, right?
+
+396
+00:23:39.180 --> 00:23:44.700
+So you now have a permission set that represents maybe what the DevOps IAM user does.
+
+397
+00:23:44.860 --> 00:23:45.780
+That's a typical thing.
+
+398
+00:23:45.840 --> 00:23:51.480
+You might find an overprivileged IAM user that was used by a certain group or a group of individuals.
+
+399
+00:23:51.480 --> 00:23:55.960
+So you can start to take little slices off of the problem like that, okay?
+
+400
+00:23:56.760 --> 00:24:01.160
+You'll often find then, you know, you could find an IAM user called S3 backup.
+
+401
+00:24:01.160 --> 00:24:06.180
+It's quite obvious what it does, but you might find that it has the Amazon S3 full access
+
+402
+00:24:06.180 --> 00:24:08.060
+managed policy attached.
+
+403
+00:24:08.440 --> 00:24:12.520
+Now, you know, we could replace that with an IAM role and just move on.
+
+404
+00:24:12.640 --> 00:24:18.620
+But we know deep within our soul, the correct thing to do here is to also evaluate that workload
+
+405
+00:24:18.620 --> 00:24:20.860
+and look at what access it actually needs.
+
+406
+00:24:21.020 --> 00:24:23.420
+So you might be able to talk to the team responsible.
+
+407
+00:24:23.840 --> 00:24:28.820
+You might be able to use IAM access analyzer, and you'll be able to create a really fine grain
+
+408
+00:24:28.820 --> 00:24:30.840
+permission for that role, right?
+
+409
+00:24:30.840 --> 00:24:32.340
+It probably only accesses one bucket.
+
+410
+00:24:32.620 --> 00:24:36.800
+It might only access a soap key within the bucket, and you can give it a very strict,
+
+411
+00:24:36.900 --> 00:24:38.220
+you know, put object policy.
+
+412
+00:24:38.760 --> 00:24:45.120
+And with every step you encounter, you're incrementally improving your posture, okay?
+
+413
+00:24:45.160 --> 00:24:47.840
+So the scream test is going to be your friend.
+
+414
+00:24:48.480 --> 00:24:51.140
+You're going to have a lot of rinse and repeat on this process.
+
+415
+00:24:51.260 --> 00:24:52.240
+But I have done it.
+
+416
+00:24:52.300 --> 00:24:52.940
+It is painful.
+
+417
+00:24:52.940 --> 00:24:54.360
+But it can be done.
+
+418
+00:24:54.520 --> 00:24:59.820
+And it's definitely one of the best things you can do for your organization from a security
+
+419
+00:24:59.820 --> 00:25:00.600
+standpoint.
+
+420
+00:25:00.820 --> 00:25:05.360
+The other aspect then is, well, what if I have a different cloud?
+
+421
+00:25:05.600 --> 00:25:11.160
+And what I mean by that usually is you could have CircleCI, GitHub Actions, HashiCorp Cloud.
+
+422
+00:25:11.160 --> 00:25:16.420
+Often, these IAM users are created because you need access from a system that is not AWS,
+
+423
+00:25:16.720 --> 00:25:19.800
+where we can't rely on assuming a role or something like that.
+
+424
+00:25:19.940 --> 00:25:23.740
+So that was a very common source of IAM users, you know, some sort of pipeline user.
+
+425
+00:25:24.280 --> 00:25:29.040
+Thankfully, in the last couple of years, OIDC identity providers have solved a lot of this.
+
+426
+00:25:29.040 --> 00:25:33.620
+I believe there's previous episodes where they're covered, but stuff like GitHub Actions will
+
+427
+00:25:33.620 --> 00:25:38.220
+now give you, you know, fine-grained access to a role to a particular repo or even to a
+
+428
+00:25:38.220 --> 00:25:44.960
+particular operation in a repo, like the repo being tagged or a release being created or a
+
+429
+00:25:44.960 --> 00:25:47.020
+certain branch name being pushed to.
+
+430
+00:25:47.320 --> 00:25:52.160
+So you can get extremely fine-grained access from GitHub Actions into AWS now as well.
+
+431
+00:25:52.280 --> 00:25:58.020
+So that's kind of the tried and true method to replace those cloud-to-cloud IAM users.
+
+432
+00:25:58.020 --> 00:26:02.540
+And I guess finally, you know, we can strive for perfection, but we're probably going to
+
+433
+00:26:02.540 --> 00:26:04.360
+have a handful of IAM users when we're finished.
+
+434
+00:26:04.520 --> 00:26:05.840
+Could be some legacy system.
+
+435
+00:26:06.340 --> 00:26:10.500
+There could be a user with a customer or on a server somewhere in the wild that we don't
+
+436
+00:26:10.500 --> 00:26:11.340
+control anymore.
+
+437
+00:26:11.760 --> 00:26:14.260
+Unfortunately, you might end up with a handful of IAM users.
+
+438
+00:26:14.600 --> 00:26:19.940
+What we recommend there is the SCP to block creation of new ones so we can at least plug
+
+439
+00:26:19.940 --> 00:26:20.400
+the leak.
+
+440
+00:26:20.520 --> 00:26:22.120
+And then we can document those users.
+
+441
+00:26:22.420 --> 00:26:26.600
+We could import them into Terraform or CloudFormation so that we have them in infrastructure as code.
+
+442
+00:26:26.600 --> 00:26:28.880
+It's easy to kind of ring fence the problem.
+
+443
+00:26:29.660 --> 00:26:34.800
+We could introduce rotation, again, if we have access to the system where they're used.
+
+444
+00:26:35.160 --> 00:26:40.260
+And you could even implement, you know, event bridge notifications, AWS Config.
+
+445
+00:26:40.780 --> 00:26:46.160
+You can just really scrutinize those IAM users and make sure we know whenever they do something
+
+446
+00:26:46.160 --> 00:26:46.640
+interesting.
+
+447
+00:26:47.000 --> 00:26:50.080
+So I think that's all I have on the topic.
+
+448
+00:26:50.080 --> 00:26:54.600
+It's a challenge, but I would say it's definitely worth doing.
+
+449
+00:26:55.000 --> 00:27:00.600
+It's a game changer for your security posture, particularly in AWS environments that have
+
+450
+00:27:00.600 --> 00:27:01.880
+been around for a couple of years.
+
+451
+00:27:02.140 --> 00:27:02.240
+Yeah.
+
+452
+00:27:02.300 --> 00:27:03.960
+Thank you for all these amazing suggestions.
+
+453
+00:27:04.240 --> 00:27:09.520
+I especially like the last one about importing the users, making sure that they're well documented,
+
+454
+00:27:10.000 --> 00:27:11.880
+creating SCPs to avoid new users.
+
+455
+00:27:12.280 --> 00:27:12.680
+And yeah.
+
+456
+00:27:12.680 --> 00:27:16.920
+Rotating credentials is something that most often, at least, is done manually.
+
+457
+00:27:17.160 --> 00:27:20.760
+So probably you want to have some kind of playbook where you kind of document very well
+
+458
+00:27:20.760 --> 00:27:21.560
+all the steps.
+
+459
+00:27:21.820 --> 00:27:25.840
+At least you can do it in a repeatable way and have a process that kind of reminds yourself
+
+460
+00:27:25.840 --> 00:27:27.040
+to do it often enough.
+
+461
+00:27:27.380 --> 00:27:29.700
+So with that, I think it's a wrap for today.
+
+462
+00:27:30.060 --> 00:27:33.900
+I hope that we have convinced you that IAM users are not a good practice.
+
+463
+00:27:34.080 --> 00:27:39.100
+I hope that we have given you enough suggestions and motivation to get started on getting rid of
+
+464
+00:27:39.100 --> 00:27:39.300
+them.
+
+465
+00:27:39.580 --> 00:27:41.960
+And hopefully you enjoyed this episode.
+
+466
+00:27:42.260 --> 00:27:44.900
+So if you've done that, please give us feedback.
+
+467
+00:27:45.020 --> 00:27:48.700
+As always, thumbs up, share, like, subscribe, and all the usual things.
+
+468
+00:27:48.940 --> 00:27:53.500
+And I want to conclude with a big thank you to Conor for bringing us a fresh perspective
+
+469
+00:27:53.500 --> 00:27:55.860
+and to be our new host for this episode.
+
+470
+00:27:56.140 --> 00:27:58.060
+So until next time, thank you very much.
+
+471
+00:27:58.140 --> 00:28:00.020
+And we'll see you in the next episode.

--- a/src/episodes/134-conor-iam.md
+++ b/src/episodes/134-conor-iam.md
@@ -1,0 +1,11 @@
+---
+episode: 134
+title: "Eliminate the IAM User"
+youtube_id: "wQM_ZqzyU_I"
+spotify_link: "https://podcasters.spotify.com/pod/show/aws-bites/episodes/134--Eliminate-the-IAM-User-e2pts0i"
+publish_date: 2024-11-01
+---
+
+In this episode, we discuss why IAM users and long-lived credentials are dangerous and should be avoided. We share war stories of compromised credentials and overprivileged access. We then explore solutions like centralizing IAM users, using tools like AWS Vault for temporary credentials, integrating with AWS SSO, and fully eliminating IAM users when possible.
+
+> AWS Bites is sponsored by fourTheorem, an Advanced AWS partner that works collaboratively with you and sets you up for long-term success on AWS. Find out more at [fourtheorem.com](https://fourtheorem.com).


### PR DESCRIPTION

# Transcript

This change includes the transcript for the podcast episode, created by [Podwhisperer](https://github.com/fourTheorem/podwhisperer).
The summary below is generated by [Episoder](https://github.com/fourTheorem/episoder).

## Episode Summary

In this episode, we discuss why IAM users and long-lived credentials are dangerous and should be avoided. We share war stories of compromised credentials and overprivileged access. We then explore solutions like centralizing IAM users, using tools like AWS Vault for temporary credentials, integrating with AWS SSO, and fully eliminating IAM users when possible.

## Suggested Chapters
00:00 Introduction
01:22 Connor introduces himself
07:46 Overview of IAM credential resolution
11:54 Mitigation strategies for existing IAM users
16:31 Modern solutions with AWS SSO and AWS IAM Identity Center
20:56 Transitioning legacy environments to eliminate IAM users
27:02 Conclusion

## Suggested Tags
AWS, IAM, Security, Credentials, Roles, STS, AWS Vault, SSO, AWS SSO, IAM Identity Center, AWS Organizations, Principals, Permissions, Access, Governance, Rotation, Offboarding
