### PR TITLE
add episode 144 transcript

### DIFF
--- a/src/_transcripts/144.json
+++ b/src/_transcripts/144.json
@@ -1,0 +1,1238 @@
+{
+  "speakers": {
+    "spk_0": "spk_0",
+    "spk_1": "spk_1"
+  },
+  "segments": [
+    {
+      "speakerLabel": "spk_0",
+      "start": 0.32,
+      "end": 3.2800000000000002,
+      "text": " Cost is always the burning topic when it comes to building in the cloud."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 3.84,
+      "end": 8.72,
+      "text": " Luckily, we've been treated to quite a few cost reductions from AWS over the years."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 9.200000000000001,
+      "end": 11.58,
+      "text": " Now and then, we can get cost increases too."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 11.94,
+      "end": 14.540000000000001,
+      "text": " And today, we're going to talk about some new updates from AWS"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 14.540000000000001,
+      "end": 19.18,
+      "text": " and zoom in on some recent cost increases as well as decreases."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 19.7,
+      "end": 21.54,
+      "text": " I'm Eoin. I'm here with Luciano."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 21.54,
+      "end": 23.94,
+      "text": " And this is AWS Bites."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 30,
+      "end": 34.12,
+      "text": " AWS Bites is brought to you by 4Theorem."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 34.42,
+      "end": 38.46,
+      "text": " Stay tuned to the end of the episode so we can tell you a lot more all about that."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 38.7,
+      "end": 42.019999999999996,
+      "text": " Now, whenever we talk about AWS Lambda, we discuss its cost model."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 42.519999999999996,
+      "end": 44.519999999999996,
+      "text": " With Lambda, you pay for the number of requests you make,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 44.86,
+      "end": 46.56,
+      "text": " which is generally the much smaller component,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 46.92,
+      "end": 49.400000000000006,
+      "text": " but you also pay for the execution duration."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 49.400000000000006,
+      "end": 52.44,
+      "text": " And that's billed in tiny one millisecond chunks."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 52.66,
+      "end": 56.42,
+      "text": " And the cost is proportional to the amount of memory you allocate for that function."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 56.6,
+      "end": 59.260000000000005,
+      "text": " And there are a few different things that can affect this cost further."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 59.26,
+      "end": 61.98,
+      "text": " Back in 2022, tiered pricing was introduced,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 62.239999999999995,
+      "end": 66.42,
+      "text": " and that lets you save up to 20% if you've got high volumes of Lambda usage."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 66.78,
+      "end": 68.52,
+      "text": " You've also got compute savings plans,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 68.62,
+      "end": 72.46,
+      "text": " which don't just apply to containers and EC2, but Lambda as well."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 72.56,
+      "end": 75.94,
+      "text": " And they let you commit to a certain spend and save up to 12%."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 75.94,
+      "end": 77.92,
+      "text": " And of course, you've also got provisioned concurrency."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 78.03999999999999,
+      "end": 79.86,
+      "text": " Now, that lets you keep functions warm,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 80.18,
+      "end": 84.44,
+      "text": " which means you're paying as long as they're provisioned and ready to process a request."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 84.58,
+      "end": 87.22,
+      "text": " But the rate you pay is less than the standard on demand rate."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 87.22,
+      "end": 91.03999999999999,
+      "text": " Now, for a long time, there has been a bit of a free lunch when it comes to Lambda billing."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 91.26,
+      "end": 92.96,
+      "text": " We're not just talking about the pretty nice free tier,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 93.24,
+      "end": 97.98,
+      "text": " but about the cold start duration, also known as the init phase, the init duration."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 98.2,
+      "end": 101.44,
+      "text": " This is the time your function takes to load the runtime of the handler code"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 101.44,
+      "end": 103.72,
+      "text": " before it actually passes the event to your function."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 104.22,
+      "end": 105.52,
+      "text": " A lot has been written about this."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 105.75999999999999,
+      "end": 109.12,
+      "text": " We'll link to a nice article by Luke van Dankerschoot,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 109.22,
+      "end": 110.66,
+      "text": " which I think we've mentioned before."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 110.66,
+      "end": 115.5,
+      "text": " Up until now, the initialization phase was not billed for managed runtimes."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 116.1,
+      "end": 121.53999999999999,
+      "text": " Those are the official runtimes like the Python, Node.js, Java, .NET, Ruby runtimes."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 121.75999999999999,
+      "end": 124.42,
+      "text": " By the way, if you want to learn about how a runtime works,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 124.52,
+      "end": 127.03999999999999,
+      "text": " we have a whole episode dedicated to that topic."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 127.19999999999999,
+      "end": 129.38,
+      "text": " That's episode 104, and you'll find the link in the description."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 129.78,
+      "end": 133.64,
+      "text": " Now, this free lunch, free unit phase thing was never something you could avail of"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 133.64,
+      "end": 134.96,
+      "text": " if you had custom runtimes."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 134.96,
+      "end": 140.14000000000001,
+      "text": " So if you were doing something like C++, Golang, C, Rust,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 140.4,
+      "end": 145,
+      "text": " or your very own custom runtime, that was never something you got."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 145.34,
+      "end": 148.24,
+      "text": " Similarly with container image packaging, which we use quite a lot now,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 148.46,
+      "end": 152.88,
+      "text": " especially for large dependencies, that never had this free init phase."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 153.26000000000002,
+      "end": 155.02,
+      "text": " And provisioned concurrency never had it either."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 155.22,
+      "end": 156.14000000000001,
+      "text": " But there is a couple of benefits."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 156.24,
+      "end": 160.28,
+      "text": " So not only was it free, you also get two vCPUs during this init phase,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 160.38,
+      "end": 162.62,
+      "text": " regardless of the amount of memory you allocate for your function."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 162.62,
+      "end": 168.08,
+      "text": " And normally the vCPUs are tied and scaled linearly with the amount of memory you allocate."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 168.24,
+      "end": 174.24,
+      "text": " So if you wanted two vCPUs, you'd have to allocate at least 3538 megabytes of memory"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 174.24,
+      "end": 175.08,
+      "text": " to get those two cores."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 175.34,
+      "end": 179.12,
+      "text": " So you had a little bit of a performance boost in that init phase to get things up and running."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 179.36,
+      "end": 181.5,
+      "text": " The maximum execution time of that phase, by the way, is 10 seconds."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 182.18,
+      "end": 186.32,
+      "text": " And if your initialization exceeds this, the function times out and gets retried."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 186.72,
+      "end": 188.76,
+      "text": " But you could get a lot done potentially in those 10 seconds."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 189.02,
+      "end": 192,
+      "text": " So AWS has potentially spotted an issue there."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 192,
+      "end": 194.58,
+      "text": " Do you want to tell us more about this and what they've done about it?"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 195.04,
+      "end": 200.02,
+      "text": " Yeah, as you can imagine, this is almost like, yeah, you mentioned it as free compute."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 200.28,
+      "end": 201.88,
+      "text": " That's what it can be used for."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 202.56,
+      "end": 204.36,
+      "text": " And ideally, you wouldn't really abuse it."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 204.54,
+      "end": 209.2,
+      "text": " Like the init phase is for, I don't know, initializing the AWS clients."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 209.2,
+      "end": 216.82,
+      "text": " Like if you want to interact with S3 or DynamoDB, or maybe load secrets or initialize other kind of clients that you might need within your Lambda."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 217.22,
+      "end": 221.2,
+      "text": " So it's to kind of initialize all of these resources that ideally you want to create once."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 221.35999999999999,
+      "end": 225.29999999999998,
+      "text": " And then for multiple events, you will be reusing those instances."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 225.3,
+      "end": 228.58,
+      "text": " So that's the kind of usual stuff that you will do with it."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 228.68,
+      "end": 233.52,
+      "text": " But you can imagine that people could do all sorts of nasty things, or maybe just use it as free compute."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 233.64000000000001,
+      "end": 240.76000000000002,
+      "text": " So like number crunching, processing, whatever they need to do, they will spin it up in a Lambda, have that code in the init phase,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 240.76,
+      "end": 247.64,
+      "text": " and then somehow make that Lambda crash or maybe change an environment variable so that a new instance would be forced for the next time that Lambda runs."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 248.14,
+      "end": 251.85999999999999,
+      "text": " And effectively, this way, you could be exploding that free compute idea."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 252.54,
+      "end": 255.94,
+      "text": " And of course, this is something that AWS probably realized."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 256.32,
+      "end": 262.48,
+      "text": " And they thought that the easiest solution is to reintroduce, to introduce billing also for this init phase,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 262.62,
+      "end": 269.18,
+      "text": " which also makes the whole cost equation a little bit more consistent, depending on your choice of runtime,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 269.18,
+      "end": 273.82,
+      "text": " or if you use something like container for image packaging, or if you use provision concurrency."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 273.82,
+      "end": 277.76,
+      "text": " So the question you might have now is, okay, I was not abusing."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 278.1,
+      "end": 283.6,
+      "text": " So that maybe seems a little bit unfair that now I need to pay for something that I was not paying before."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 284.04,
+      "end": 291.2,
+      "text": " So yes, what kind of impact can it have in real use cases where you're actually running a business and doing useful stuff?"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 291.26,
+      "end": 294.12,
+      "text": " You're not just trying to exploit AWS free compute."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 294.62,
+      "end": 296.66,
+      "text": " And it's not easy to answer this question."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 296.66,
+      "end": 299.22,
+      "text": " Of course, your mileage might vary."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 299.5,
+      "end": 304.68,
+      "text": " I think for most people, at least this is our belief, the impact is going to be very minimal."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 304.82000000000005,
+      "end": 306.36,
+      "text": " Probably you won't even notice."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 306.84000000000003,
+      "end": 311.34000000000003,
+      "text": " There might be some extreme cases where maybe you have lots and lots of cold starts,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 311.34000000000003,
+      "end": 315.5,
+      "text": " or maybe where you have lots of invocations in general,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 315.72,
+      "end": 321.48,
+      "text": " but the ratio between the initial injection phase, time, and the execution phase is very high."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 321.48,
+      "end": 327.14000000000004,
+      "text": " In this case, you might see maybe a little bit of extra cost because, of course, you are doing a lot of init,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 327.3,
+      "end": 329.48,
+      "text": " and now you're getting billed for that init time."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 329.90000000000003,
+      "end": 334.86,
+      "text": " Now, another question you might have is, does this make a better case for highly efficient custom runtimes,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 335.32,
+      "end": 341.22,
+      "text": " like compile languages, as we mentioned already, Rust, C++, Go, or maybe if you use other ones,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 341.28000000000003,
+      "end": 346.22,
+      "text": " maybe you can bring your own custom runtime and run code written in other compile languages?"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 346.22,
+      "end": 352.02000000000004,
+      "text": " This is also a very difficult question because I think you need to analyze exactly your use cases."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 352.20000000000005,
+      "end": 355.14000000000004,
+      "text": " So I would say it might make a difference or not."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 355.34000000000003,
+      "end": 360.46000000000004,
+      "text": " In general, I think what is worth understanding is that the init phase duration with custom runtimes,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 360.64000000000004,
+      "end": 363.64000000000004,
+      "text": " when you use compiled languages, can be much faster."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 363.98,
+      "end": 369.98,
+      "text": " So if you're really looking for reducing that cold start, either for cost reasons,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 369.98,
+      "end": 373.52000000000004,
+      "text": " or maybe because maybe you have APIs that are running in Lambda,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 373.88,
+      "end": 380.08000000000004,
+      "text": " so you don't want to have occasional extra latency just because you happen to have a request"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 380.08000000000004,
+      "end": 384.90000000000003,
+      "text": " that is actually creating a Lambda for the first time, so the user might perceive that cold start."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 385.52000000000004,
+      "end": 390.72,
+      "text": " I think using languages like Rust, C++, or Go can make a little bit of a difference."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 391.04,
+      "end": 393.14000000000004,
+      "text": " Now, difficult to give you exact numbers."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 393.3,
+      "end": 396.40000000000003,
+      "text": " There is actually a very good benchmark by Maxim David."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 396.58000000000004,
+      "end": 397.8,
+      "text": " We've mentioned it a few times."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 397.90000000000003,
+      "end": 399.06,
+      "text": " We'll leave the link in the show notes."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 399.06,
+      "end": 404.56,
+      "text": " You can open this benchmark and see a comparison between a big matrix of combinations"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 404.56,
+      "end": 407.86,
+      "text": " between memory, runtime, type of CPU architecture,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 408.24,
+      "end": 412.46,
+      "text": " and try to figure out by yourself what is maybe a good combination for you."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 412.58,
+      "end": 415.14,
+      "text": " Of course, we are not advocating for rewriting everything in Rust,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 415.5,
+      "end": 418.82,
+      "text": " although I would like that, but maybe not always the most pragmatic choice."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 419.68,
+      "end": 423.26,
+      "text": " But I will say, again, if you really have a Lambda,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 423.38,
+      "end": 426.28,
+      "text": " that maybe you are running thousands or even millions of times per day,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 426.28,
+      "end": 431,
+      "text": " or maybe you are actually trying to build very efficient HTTP APIs on Lambda,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 431.28,
+      "end": 435.15999999999997,
+      "text": " you might actually justify the investment of rewriting some of that code in Rust"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 435.15999999999997,
+      "end": 439,
+      "text": " or other combined languages to keep it as fast and snappy as possible."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 439.2,
+      "end": 443.96,
+      "text": " And there is, of course, another element that we always think a little bit as a secondary element,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 443.96,
+      "end": 445.34,
+      "text": " but it's actually quite important."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 445.34,
+      "end": 450.38,
+      "text": " If you get about carbon impact, those languages generally have a much better carbon footprint."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 450.78,
+      "end": 454.52,
+      "text": " So that's another reason maybe to explore a little bit more this option."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 454.84,
+      "end": 458.46,
+      "text": " Now let's get back into logging cost reduction."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 463.4,
+      "end": 466.21999999999997,
+      "text": " Yeah, when we talk about Lambda costs, we're talking a lot about the execution time, but of course there's always the side effects with AWS services,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 466.21999999999997,
+      "end": 470.76,
+      "text": " since you generally need other services enabled to use things like Lambda effectively."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 470.76,
+      "end": 475.15999999999997,
+      "text": " CloudWatch costs, in particular logs, are the primary culprit here."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 475.15999999999997,
+      "end": 479.5,
+      "text": " The situation used to be pretty much that CloudWatch logs was the only destination for your logs,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 479.7,
+      "end": 482.98,
+      "text": " and you'd pay 50 cents per gigabyte of log collection"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 482.98,
+      "end": 488.21999999999997,
+      "text": " and around three cents per gigabyte of compressed storage thereafter."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 488.92,
+      "end": 494.8,
+      "text": " And a while back, AWS made a really nice change by adding an infrequent access tier for logs,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 494.96,
+      "end": 498.7,
+      "text": " which reduces the storage cost by 50%, so that can make a big difference already."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 498.7,
+      "end": 503.84,
+      "text": " Now, since the start of May 2025 this year, we have even more cost-saving possibilities."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 504.4,
+      "end": 509.7,
+      "text": " So the main announcement was that they announced the pricing is now tiered based on usage."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 510.15999999999997,
+      "end": 511.14,
+      "text": " So what are the tiers?"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 511.5,
+      "end": 514.2,
+      "text": " Well, if you have over 10 terabytes per month per account,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 514.4,
+      "end": 520.04,
+      "text": " you'll only pay 25 cents per gigabyte for standard access and 15 cents for infrequent access."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 520.16,
+      "end": 522.64,
+      "text": " That's for anything over that 10 terabyte threshold."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 522.78,
+      "end": 525.3,
+      "text": " So anything up to that initial threshold, you're still paying the old price."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 525.3,
+      "end": 528.0999999999999,
+      "text": " And there are more tiers then in steps of 20 terabytes."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 528.4,
+      "end": 533.88,
+      "text": " And then if you have a lot of logs, anything over 50 terabytes is as low as five cents per gigabyte,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 533.9599999999999,
+      "end": 535.74,
+      "text": " whether that's standard or infrequent access."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 536.18,
+      "end": 540.3599999999999,
+      "text": " Now, these thresholds are pretty high, so it won't benefit everybody, unfortunately."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 540.9599999999999,
+      "end": 544.8399999999999,
+      "text": " But if you've got a massive CloudWatch logs bill because of your extensive use of Lambda,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 545.26,
+      "end": 547.06,
+      "text": " it can make a big difference."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 547.3599999999999,
+      "end": 550.52,
+      "text": " Eric Pullen from the Duckbill group actually wrote a nice article all on this,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 550.52,
+      "end": 556.06,
+      "text": " and even share the calculator script that you can run against your account to estimate how much you might save."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 556.48,
+      "end": 561.5799999999999,
+      "text": " So I'd recommend checking that out and seeing if it's going to be a big lever for you."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 561.8,
+      "end": 568.18,
+      "text": " Yeah, another interesting change which might help with cost reduction is that now you have new destinations for Lambda logs."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 568.5799999999999,
+      "end": 572.36,
+      "text": " As you said, it was the case that you can only send stuff to CloudWatch."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 572.36,
+      "end": 577.1,
+      "text": " Now you can actually send logs to S3 and Firehose instead of just CloudWatch."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 577.64,
+      "end": 586.3000000000001,
+      "text": " And I think this will be very useful for you if you already have processes that take CloudWatch logs and send them to other destinations."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 586.3000000000001,
+      "end": 591.74,
+      "text": " You were effectively using CloudWatch logs almost like as a transitioning storage,"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 591.96,
+      "end": 595.5,
+      "text": " and maybe not even ever consuming data directly from CloudWatch logs."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 595.5,
+      "end": 604.12,
+      "text": " Now you can skip all of that cost and maybe use Firehose to send the data directly to whatever is your final storage to consume the logs."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 604.62,
+      "end": 608.62,
+      "text": " And this is generally something that can happen if you use, for instance, third-party tools for observability."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 608.88,
+      "end": 612.6,
+      "text": " So now there might be more options to make that integration a little bit cheaper."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 613.36,
+      "end": 615.54,
+      "text": " And I think that's always nice."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 615.82,
+      "end": 618.56,
+      "text": " And also, in another sense, it removes a little bit of complexity"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 618.56,
+      "end": 623.52,
+      "text": " because your architecture doesn't need a component that just moves data from A to B."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 623.52,
+      "end": 626.4,
+      "text": " Of course, this is not free."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 626.64,
+      "end": 630.5799999999999,
+      "text": " There is a cost to use this new S3 or Firehose destination."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 630.88,
+      "end": 635.76,
+      "text": " You still pay up to $0.25 per gigabyte for log delivery to S3 and Firehose."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 636.04,
+      "end": 640.86,
+      "text": " And then, of course, you have the cost of the S3 and Firehose services as well that you need to keep into account."
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 641.38,
+      "end": 647.46,
+      "text": " Are there some recommendations that we can give to people in case they maybe want to learn a trick or two"
+    },
+    {
+      "speakerLabel": "spk_1",
+      "start": 647.46,
+      "end": 651.66,
+      "text": " on how they can save a little bit of cost when it comes to Lambda and logs in general?"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 655.64,
+      "end": 660.5799999999999,
+      "text": " Yeah, even if we forget about all of these changes we've discussed today, whether those cost changes impact you at all, the cost of logging is something you should keep an eye on."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 661,
+      "end": 663.62,
+      "text": " And we can give you a few relatively quick recommendations."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 663.92,
+      "end": 666.3,
+      "text": " Of course, we'd love to hear your tips, so let us know what you think."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 666.54,
+      "end": 668.86,
+      "text": " Number one is using frequent access wherever possible."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 669.18,
+      "end": 674.7199999999999,
+      "text": " We've adopted this since it was made available as our default almost, and we rarely miss standard access mode."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 674.72,
+      "end": 679.28,
+      "text": " It has some limitations, like you can't use LiveTail embedded metrics and metric filters,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 679.8000000000001,
+      "end": 683.98,
+      "text": " but you can still use Logs Insights, which is what we primarily use for viewing and searching logs."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 684.4200000000001,
+      "end": 687.1,
+      "text": " We have a whole episode on that, actually, which is episode 35."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 687.46,
+      "end": 688.9,
+      "text": " And yeah, you can check that out."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 689.12,
+      "end": 691.88,
+      "text": " I'd also say set the log retention period to a reasonable value."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 692.28,
+      "end": 695.52,
+      "text": " Often you don't need to retain Lambda logs for months, and often by default,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 695.76,
+      "end": 699.34,
+      "text": " they can be retained indefinitely, which can really cause you a lot of pain."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 699.5600000000001,
+      "end": 703.24,
+      "text": " Experiment with the other new feature, which is advanced logging controls."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 703.24,
+      "end": 704.88,
+      "text": " I think this was released last year."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 705.54,
+      "end": 710.32,
+      "text": " Lambda can actually filter out verbose logging, like debug level for you, and you can save costs that way."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 710.48,
+      "end": 714.48,
+      "text": " And if you're using AWS Power Tools for Lambda, you can also do debug log sampling,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 714.64,
+      "end": 721.0600000000001,
+      "text": " so that it'll only print out debug logs for a certain threshold, certain percentage of events."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 721.2,
+      "end": 722.54,
+      "text": " That can save you a lot, too."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 722.96,
+      "end": 724.82,
+      "text": " And you can also customize that per environment."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 725.1800000000001,
+      "end": 729.44,
+      "text": " And again, once features have stabilized, just remove unnecessary informative logging."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 729.44,
+      "end": 735.1400000000001,
+      "text": " I've heard stories from people who were investigating cloud costs because it became critical,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 735.5600000000001,
+      "end": 739.0600000000001,
+      "text": " and they discovered that they were paying thousands every month for logs that say,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 739.4000000000001,
+      "end": 740.74,
+      "text": " I'm here on line 23."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 741.3800000000001,
+      "end": 743.94,
+      "text": " And that was put in for debug logging during feature development."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 744.2,
+      "end": 749.4000000000001,
+      "text": " Somebody forgot to take it out, and it ended up costing tens of thousands of dollars for absolutely no reason."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 749.6,
+      "end": 753.5200000000001,
+      "text": " So just to wrap up then, we just gave a quick overview of some of the nice updates"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 753.5200000000001,
+      "end": 756.2600000000001,
+      "text": " that might help us save a few dollars on that AWS bill."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 756.26,
+      "end": 761.72,
+      "text": " We also said we'd mention a shout-out to ForTheorem for powering yet another episode of AWS Bites."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 762.06,
+      "end": 766.22,
+      "text": " And at ForTheorem, we believe that cloud should be simple, scalable, and cost-effective."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 766.5,
+      "end": 768.56,
+      "text": " And we help teams to do just that."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 768.9399999999999,
+      "end": 772.3199999999999,
+      "text": " Whether you're working with containers, stepping into event-driven architecture,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 772.68,
+      "end": 774.98,
+      "text": " or scaling a global SaaS platform on AWS,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 775.26,
+      "end": 778.8,
+      "text": " or even just trying to keep cloud spend under control, we have your back."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 778.96,
+      "end": 783.02,
+      "text": " So visit ForTheorem.com to see how we can help you build faster, better,"
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 783.02,
+      "end": 786.02,
+      "text": " and with more confidence using AWS Cloud."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 786.6,
+      "end": 787.0799999999999,
+      "text": " And that's all."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 787.3,
+      "end": 788.04,
+      "text": " Let us know what you think."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 788.28,
+      "end": 791.3,
+      "text": " And if you know somebody who might find this episode useful, please share it with them."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 791.78,
+      "end": 792.34,
+      "text": " Thanks again."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 792.68,
+      "end": 793.78,
+      "text": " Until next time, goodbye."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 793.78,
+      "end": 794.04,
+      "text": " Bye-bye."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 794.04,
+      "end": 794.14,
+      "text": " Bye-bye."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 794.14,
+      "end": 797.92,
+      "text": " Bye-bye."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 798.1,
+      "end": 798.48,
+      "text": " Bye-bye."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 798.48,
+      "end": 800.5799999999999,
+      "text": " Bye."
+    },
+    {
+      "speakerLabel": "spk_0",
+      "start": 801.1999999999999,
+      "end": 804.04,
+      "text": " Bye-bye."
+    }
+  ]
+}

--- a/src/_transcripts/144.json
+++ b/src/_transcripts/144.json
@@ -416,7 +416,7 @@
       "speakerLabel": "spk_1",
       "start": 248.14,
       "end": 251.85999999999999,
-      "text": " And effectively, this way, you could be exploding that free compute idea."
+      "text": " And effectively, this way, you could be exploiting that free compute idea."
     },
     {
       "speakerLabel": "spk_1",
@@ -602,7 +602,7 @@
       "speakerLabel": "spk_1",
       "start": 393.3,
       "end": 396.40000000000003,
-      "text": " There is actually a very good benchmark by Maxim David."
+      "text": " There is actually a very good benchmark by Maxime David."
     },
     {
       "speakerLabel": "spk_1",

--- a/src/_transcripts/144.json
+++ b/src/_transcripts/144.json
@@ -1,7 +1,7 @@
 {
   "speakers": {
-    "spk_0": "spk_0",
-    "spk_1": "spk_1"
+    "spk_0": "Eoin",
+    "spk_1": "Luciano"
   },
   "segments": [
     {
@@ -50,7 +50,7 @@
       "speakerLabel": "spk_0",
       "start": 30,
       "end": 34.12,
-      "text": " AWS Bites is brought to you by 4Theorem."
+      "text": " AWS Bites is brought to you by fourTheorem."
     },
     {
       "speakerLabel": "spk_0",
@@ -194,7 +194,7 @@
       "speakerLabel": "spk_0",
       "start": 105.75999999999999,
       "end": 109.12,
-      "text": " We'll link to a nice article by Luke van Dankerschoot,"
+      "text": " We'll link to a nice article by Luc van Donkersgoed."
     },
     {
       "speakerLabel": "spk_0",
@@ -347,7 +347,7 @@
       "text": " Do you want to tell us more about this and what they've done about it?"
     },
     {
-      "speakerLabel": "spk_0",
+      "speakerLabel": "spk_1",
       "start": 195.04,
       "end": 200.02,
       "text": " Yeah, as you can imagine, this is almost like, yeah, you mentioned it as free compute."
@@ -851,7 +851,7 @@
       "text": " So I'd recommend checking that out and seeing if it's going to be a big lever for you."
     },
     {
-      "speakerLabel": "spk_0",
+      "speakerLabel": "spk_1",
       "start": 561.8,
       "end": 568.18,
       "text": " Yeah, another interesting change which might help with cost reduction is that now you have new destinations for Lambda logs."
@@ -1160,7 +1160,7 @@
       "speakerLabel": "spk_0",
       "start": 778.96,
       "end": 783.02,
-      "text": " So visit ForTheorem.com to see how we can help you build faster, better,"
+      "text": " So visit fourtheorem.com to see how we can help you build faster, better,"
     },
     {
       "speakerLabel": "spk_0",
@@ -1197,42 +1197,6 @@
       "start": 792.68,
       "end": 793.78,
       "text": " Until next time, goodbye."
-    },
-    {
-      "speakerLabel": "spk_0",
-      "start": 793.78,
-      "end": 794.04,
-      "text": " Bye-bye."
-    },
-    {
-      "speakerLabel": "spk_0",
-      "start": 794.04,
-      "end": 794.14,
-      "text": " Bye-bye."
-    },
-    {
-      "speakerLabel": "spk_0",
-      "start": 794.14,
-      "end": 797.92,
-      "text": " Bye-bye."
-    },
-    {
-      "speakerLabel": "spk_0",
-      "start": 798.1,
-      "end": 798.48,
-      "text": " Bye-bye."
-    },
-    {
-      "speakerLabel": "spk_0",
-      "start": 798.48,
-      "end": 800.5799999999999,
-      "text": " Bye."
-    },
-    {
-      "speakerLabel": "spk_0",
-      "start": 801.1999999999999,
-      "end": 804.04,
-      "text": " Bye-bye."
     }
   ]
 }

--- a/src/_transcripts/144.vtt
+++ b/src/_transcripts/144.vtt
@@ -274,7 +274,7 @@ and then somehow make that Lambda crash or maybe change an environment variable 
 
 69
 00:04:08.140 --> 00:04:11.860
-And effectively, this way, you could be exploding that free compute idea.
+And effectively, this way, you could be exploiting that free compute idea.
 
 70
 00:04:12.540 --> 00:04:15.940
@@ -398,7 +398,7 @@ Now, difficult to give you exact numbers.
 
 100
 00:06:33.300 --> 00:06:36.400
-There is actually a very good benchmark by Maxim David.
+There is actually a very good benchmark by Maxime David.
 
 101
 00:06:36.580 --> 00:06:37.800

--- a/src/_transcripts/144.vtt
+++ b/src/_transcripts/144.vtt
@@ -1,0 +1,797 @@
+WEBVTT
+
+1
+00:00:00.320 --> 00:00:03.280
+Cost is always the burning topic when it comes to building in the cloud.
+
+2
+00:00:03.840 --> 00:00:08.720
+Luckily, we've been treated to quite a few cost reductions from AWS over the years.
+
+3
+00:00:09.200 --> 00:00:11.580
+Now and then, we can get cost increases too.
+
+4
+00:00:11.940 --> 00:00:14.540
+And today, we're going to talk about some new updates from AWS
+
+5
+00:00:14.540 --> 00:00:19.180
+and zoom in on some recent cost increases as well as decreases.
+
+6
+00:00:19.700 --> 00:00:21.540
+I'm Eoin. I'm here with Luciano.
+
+7
+00:00:21.540 --> 00:00:23.940
+And this is AWS Bites.
+
+8
+00:00:30.000 --> 00:00:34.120
+AWS Bites is brought to you by fourTheorem.
+
+9
+00:00:34.420 --> 00:00:38.460
+Stay tuned to the end of the episode so we can tell you a lot more all about that.
+
+10
+00:00:38.700 --> 00:00:42.020
+Now, whenever we talk about AWS Lambda, we discuss its cost model.
+
+11
+00:00:42.520 --> 00:00:44.520
+With Lambda, you pay for the number of requests you make,
+
+12
+00:00:44.860 --> 00:00:46.560
+which is generally the much smaller component,
+
+13
+00:00:46.920 --> 00:00:49.400
+but you also pay for the execution duration.
+
+14
+00:00:49.400 --> 00:00:52.440
+And that's billed in tiny one millisecond chunks.
+
+15
+00:00:52.660 --> 00:00:56.420
+And the cost is proportional to the amount of memory you allocate for that function.
+
+16
+00:00:56.600 --> 00:00:59.260
+And there are a few different things that can affect this cost further.
+
+17
+00:00:59.260 --> 00:01:01.980
+Back in 2022, tiered pricing was introduced,
+
+18
+00:01:02.240 --> 00:01:06.420
+and that lets you save up to 20% if you've got high volumes of Lambda usage.
+
+19
+00:01:06.780 --> 00:01:08.520
+You've also got compute savings plans,
+
+20
+00:01:08.620 --> 00:01:12.460
+which don't just apply to containers and EC2, but Lambda as well.
+
+21
+00:01:12.560 --> 00:01:15.940
+And they let you commit to a certain spend and save up to 12%.
+
+22
+00:01:15.940 --> 00:01:17.920
+And of course, you've also got provisioned concurrency.
+
+23
+00:01:18.040 --> 00:01:19.860
+Now, that lets you keep functions warm,
+
+24
+00:01:20.180 --> 00:01:24.440
+which means you're paying as long as they're provisioned and ready to process a request.
+
+25
+00:01:24.580 --> 00:01:27.220
+But the rate you pay is less than the standard on demand rate.
+
+26
+00:01:27.220 --> 00:01:31.040
+Now, for a long time, there has been a bit of a free lunch when it comes to Lambda billing.
+
+27
+00:01:31.260 --> 00:01:32.960
+We're not just talking about the pretty nice free tier,
+
+28
+00:01:33.240 --> 00:01:37.980
+but about the cold start duration, also known as the init phase, the init duration.
+
+29
+00:01:38.200 --> 00:01:41.440
+This is the time your function takes to load the runtime of the handler code
+
+30
+00:01:41.440 --> 00:01:43.720
+before it actually passes the event to your function.
+
+31
+00:01:44.220 --> 00:01:45.520
+A lot has been written about this.
+
+32
+00:01:45.760 --> 00:01:49.120
+We'll link to a nice article by Luc van Donkersgoed.
+
+33
+00:01:49.220 --> 00:01:50.660
+which I think we've mentioned before.
+
+34
+00:01:50.660 --> 00:01:55.500
+Up until now, the initialization phase was not billed for managed runtimes.
+
+35
+00:01:56.100 --> 00:02:01.540
+Those are the official runtimes like the Python, Node.js, Java, .NET, Ruby runtimes.
+
+36
+00:02:01.760 --> 00:02:04.420
+By the way, if you want to learn about how a runtime works,
+
+37
+00:02:04.520 --> 00:02:07.040
+we have a whole episode dedicated to that topic.
+
+38
+00:02:07.200 --> 00:02:09.380
+That's episode 104, and you'll find the link in the description.
+
+39
+00:02:09.780 --> 00:02:13.640
+Now, this free lunch, free unit phase thing was never something you could avail of
+
+40
+00:02:13.640 --> 00:02:14.960
+if you had custom runtimes.
+
+41
+00:02:14.960 --> 00:02:20.140
+So if you were doing something like C++, Golang, C, Rust,
+
+42
+00:02:20.400 --> 00:02:25.000
+or your very own custom runtime, that was never something you got.
+
+43
+00:02:25.340 --> 00:02:28.240
+Similarly with container image packaging, which we use quite a lot now,
+
+44
+00:02:28.460 --> 00:02:32.880
+especially for large dependencies, that never had this free init phase.
+
+45
+00:02:33.260 --> 00:02:35.020
+And provisioned concurrency never had it either.
+
+46
+00:02:35.220 --> 00:02:36.140
+But there is a couple of benefits.
+
+47
+00:02:36.240 --> 00:02:40.280
+So not only was it free, you also get two vCPUs during this init phase,
+
+48
+00:02:40.380 --> 00:02:42.620
+regardless of the amount of memory you allocate for your function.
+
+49
+00:02:42.620 --> 00:02:48.080
+And normally the vCPUs are tied and scaled linearly with the amount of memory you allocate.
+
+50
+00:02:48.240 --> 00:02:54.240
+So if you wanted two vCPUs, you'd have to allocate at least 3538 megabytes of memory
+
+51
+00:02:54.240 --> 00:02:55.080
+to get those two cores.
+
+52
+00:02:55.340 --> 00:02:59.120
+So you had a little bit of a performance boost in that init phase to get things up and running.
+
+53
+00:02:59.360 --> 00:03:01.500
+The maximum execution time of that phase, by the way, is 10 seconds.
+
+54
+00:03:02.180 --> 00:03:06.320
+And if your initialization exceeds this, the function times out and gets retried.
+
+55
+00:03:06.720 --> 00:03:08.760
+But you could get a lot done potentially in those 10 seconds.
+
+56
+00:03:09.020 --> 00:03:12.000
+So AWS has potentially spotted an issue there.
+
+57
+00:03:12.000 --> 00:03:14.580
+Do you want to tell us more about this and what they've done about it?
+
+58
+00:03:15.040 --> 00:03:20.020
+Yeah, as you can imagine, this is almost like, yeah, you mentioned it as free compute.
+
+59
+00:03:20.280 --> 00:03:21.880
+That's what it can be used for.
+
+60
+00:03:22.560 --> 00:03:24.360
+And ideally, you wouldn't really abuse it.
+
+61
+00:03:24.540 --> 00:03:29.200
+Like the init phase is for, I don't know, initializing the AWS clients.
+
+62
+00:03:29.200 --> 00:03:36.820
+Like if you want to interact with S3 or DynamoDB, or maybe load secrets or initialize other kind of clients that you might need within your Lambda.
+
+63
+00:03:37.220 --> 00:03:41.200
+So it's to kind of initialize all of these resources that ideally you want to create once.
+
+64
+00:03:41.360 --> 00:03:45.300
+And then for multiple events, you will be reusing those instances.
+
+65
+00:03:45.300 --> 00:03:48.580
+So that's the kind of usual stuff that you will do with it.
+
+66
+00:03:48.680 --> 00:03:53.520
+But you can imagine that people could do all sorts of nasty things, or maybe just use it as free compute.
+
+67
+00:03:53.640 --> 00:04:00.760
+So like number crunching, processing, whatever they need to do, they will spin it up in a Lambda, have that code in the init phase,
+
+68
+00:04:00.760 --> 00:04:07.640
+and then somehow make that Lambda crash or maybe change an environment variable so that a new instance would be forced for the next time that Lambda runs.
+
+69
+00:04:08.140 --> 00:04:11.860
+And effectively, this way, you could be exploding that free compute idea.
+
+70
+00:04:12.540 --> 00:04:15.940
+And of course, this is something that AWS probably realized.
+
+71
+00:04:16.320 --> 00:04:22.480
+And they thought that the easiest solution is to reintroduce, to introduce billing also for this init phase,
+
+72
+00:04:22.620 --> 00:04:29.180
+which also makes the whole cost equation a little bit more consistent, depending on your choice of runtime,
+
+73
+00:04:29.180 --> 00:04:33.820
+or if you use something like container for image packaging, or if you use provision concurrency.
+
+74
+00:04:33.820 --> 00:04:37.760
+So the question you might have now is, okay, I was not abusing.
+
+75
+00:04:38.100 --> 00:04:43.600
+So that maybe seems a little bit unfair that now I need to pay for something that I was not paying before.
+
+76
+00:04:44.040 --> 00:04:51.200
+So yes, what kind of impact can it have in real use cases where you're actually running a business and doing useful stuff?
+
+77
+00:04:51.260 --> 00:04:54.120
+You're not just trying to exploit AWS free compute.
+
+78
+00:04:54.620 --> 00:04:56.660
+And it's not easy to answer this question.
+
+79
+00:04:56.660 --> 00:04:59.220
+Of course, your mileage might vary.
+
+80
+00:04:59.500 --> 00:05:04.680
+I think for most people, at least this is our belief, the impact is going to be very minimal.
+
+81
+00:05:04.820 --> 00:05:06.360
+Probably you won't even notice.
+
+82
+00:05:06.840 --> 00:05:11.340
+There might be some extreme cases where maybe you have lots and lots of cold starts,
+
+83
+00:05:11.340 --> 00:05:15.500
+or maybe where you have lots of invocations in general,
+
+84
+00:05:15.720 --> 00:05:21.480
+but the ratio between the initial injection phase, time, and the execution phase is very high.
+
+85
+00:05:21.480 --> 00:05:27.140
+In this case, you might see maybe a little bit of extra cost because, of course, you are doing a lot of init,
+
+86
+00:05:27.300 --> 00:05:29.480
+and now you're getting billed for that init time.
+
+87
+00:05:29.900 --> 00:05:34.860
+Now, another question you might have is, does this make a better case for highly efficient custom runtimes,
+
+88
+00:05:35.320 --> 00:05:41.220
+like compile languages, as we mentioned already, Rust, C++, Go, or maybe if you use other ones,
+
+89
+00:05:41.280 --> 00:05:46.220
+maybe you can bring your own custom runtime and run code written in other compile languages?
+
+90
+00:05:46.220 --> 00:05:52.020
+This is also a very difficult question because I think you need to analyze exactly your use cases.
+
+91
+00:05:52.200 --> 00:05:55.140
+So I would say it might make a difference or not.
+
+92
+00:05:55.340 --> 00:06:00.460
+In general, I think what is worth understanding is that the init phase duration with custom runtimes,
+
+93
+00:06:00.640 --> 00:06:03.640
+when you use compiled languages, can be much faster.
+
+94
+00:06:03.980 --> 00:06:09.980
+So if you're really looking for reducing that cold start, either for cost reasons,
+
+95
+00:06:09.980 --> 00:06:13.520
+or maybe because maybe you have APIs that are running in Lambda,
+
+96
+00:06:13.880 --> 00:06:20.080
+so you don't want to have occasional extra latency just because you happen to have a request
+
+97
+00:06:20.080 --> 00:06:24.900
+that is actually creating a Lambda for the first time, so the user might perceive that cold start.
+
+98
+00:06:25.520 --> 00:06:30.720
+I think using languages like Rust, C++, or Go can make a little bit of a difference.
+
+99
+00:06:31.040 --> 00:06:33.140
+Now, difficult to give you exact numbers.
+
+100
+00:06:33.300 --> 00:06:36.400
+There is actually a very good benchmark by Maxim David.
+
+101
+00:06:36.580 --> 00:06:37.800
+We've mentioned it a few times.
+
+102
+00:06:37.900 --> 00:06:39.060
+We'll leave the link in the show notes.
+
+103
+00:06:39.060 --> 00:06:44.560
+You can open this benchmark and see a comparison between a big matrix of combinations
+
+104
+00:06:44.560 --> 00:06:47.860
+between memory, runtime, type of CPU architecture,
+
+105
+00:06:48.240 --> 00:06:52.460
+and try to figure out by yourself what is maybe a good combination for you.
+
+106
+00:06:52.580 --> 00:06:55.140
+Of course, we are not advocating for rewriting everything in Rust,
+
+107
+00:06:55.500 --> 00:06:58.820
+although I would like that, but maybe not always the most pragmatic choice.
+
+108
+00:06:59.680 --> 00:07:03.260
+But I will say, again, if you really have a Lambda,
+
+109
+00:07:03.380 --> 00:07:06.280
+that maybe you are running thousands or even millions of times per day,
+
+110
+00:07:06.280 --> 00:07:11.000
+or maybe you are actually trying to build very efficient HTTP APIs on Lambda,
+
+111
+00:07:11.280 --> 00:07:15.160
+you might actually justify the investment of rewriting some of that code in Rust
+
+112
+00:07:15.160 --> 00:07:19.000
+or other combined languages to keep it as fast and snappy as possible.
+
+113
+00:07:19.200 --> 00:07:23.960
+And there is, of course, another element that we always think a little bit as a secondary element,
+
+114
+00:07:23.960 --> 00:07:25.340
+but it's actually quite important.
+
+115
+00:07:25.340 --> 00:07:30.380
+If you get about carbon impact, those languages generally have a much better carbon footprint.
+
+116
+00:07:30.780 --> 00:07:34.520
+So that's another reason maybe to explore a little bit more this option.
+
+117
+00:07:34.840 --> 00:07:38.460
+Now let's get back into logging cost reduction.
+
+118
+00:07:43.400 --> 00:07:46.220
+Yeah, when we talk about Lambda costs, we're talking a lot about the execution time, but of course there's always the side effects with AWS services,
+
+119
+00:07:46.220 --> 00:07:50.760
+since you generally need other services enabled to use things like Lambda effectively.
+
+120
+00:07:50.760 --> 00:07:55.160
+CloudWatch costs, in particular logs, are the primary culprit here.
+
+121
+00:07:55.160 --> 00:07:59.500
+The situation used to be pretty much that CloudWatch logs was the only destination for your logs,
+
+122
+00:07:59.700 --> 00:08:02.980
+and you'd pay 50 cents per gigabyte of log collection
+
+123
+00:08:02.980 --> 00:08:08.220
+and around three cents per gigabyte of compressed storage thereafter.
+
+124
+00:08:08.920 --> 00:08:14.800
+And a while back, AWS made a really nice change by adding an infrequent access tier for logs,
+
+125
+00:08:14.960 --> 00:08:18.700
+which reduces the storage cost by 50%, so that can make a big difference already.
+
+126
+00:08:18.700 --> 00:08:23.840
+Now, since the start of May 2025 this year, we have even more cost-saving possibilities.
+
+127
+00:08:24.400 --> 00:08:29.700
+So the main announcement was that they announced the pricing is now tiered based on usage.
+
+128
+00:08:30.160 --> 00:08:31.140
+So what are the tiers?
+
+129
+00:08:31.500 --> 00:08:34.200
+Well, if you have over 10 terabytes per month per account,
+
+130
+00:08:34.400 --> 00:08:40.040
+you'll only pay 25 cents per gigabyte for standard access and 15 cents for infrequent access.
+
+131
+00:08:40.160 --> 00:08:42.640
+That's for anything over that 10 terabyte threshold.
+
+132
+00:08:42.780 --> 00:08:45.300
+So anything up to that initial threshold, you're still paying the old price.
+
+133
+00:08:45.300 --> 00:08:48.100
+And there are more tiers then in steps of 20 terabytes.
+
+134
+00:08:48.400 --> 00:08:53.880
+And then if you have a lot of logs, anything over 50 terabytes is as low as five cents per gigabyte,
+
+135
+00:08:53.960 --> 00:08:55.740
+whether that's standard or infrequent access.
+
+136
+00:08:56.180 --> 00:09:00.360
+Now, these thresholds are pretty high, so it won't benefit everybody, unfortunately.
+
+137
+00:09:00.960 --> 00:09:04.840
+But if you've got a massive CloudWatch logs bill because of your extensive use of Lambda,
+
+138
+00:09:05.260 --> 00:09:07.060
+it can make a big difference.
+
+139
+00:09:07.360 --> 00:09:10.520
+Eric Pullen from the Duckbill group actually wrote a nice article all on this,
+
+140
+00:09:10.520 --> 00:09:16.060
+and even share the calculator script that you can run against your account to estimate how much you might save.
+
+141
+00:09:16.480 --> 00:09:21.580
+So I'd recommend checking that out and seeing if it's going to be a big lever for you.
+
+142
+00:09:21.800 --> 00:09:28.180
+Yeah, another interesting change which might help with cost reduction is that now you have new destinations for Lambda logs.
+
+143
+00:09:28.580 --> 00:09:32.360
+As you said, it was the case that you can only send stuff to CloudWatch.
+
+144
+00:09:32.360 --> 00:09:37.100
+Now you can actually send logs to S3 and Firehose instead of just CloudWatch.
+
+145
+00:09:37.640 --> 00:09:46.300
+And I think this will be very useful for you if you already have processes that take CloudWatch logs and send them to other destinations.
+
+146
+00:09:46.300 --> 00:09:51.740
+You were effectively using CloudWatch logs almost like as a transitioning storage,
+
+147
+00:09:51.960 --> 00:09:55.500
+and maybe not even ever consuming data directly from CloudWatch logs.
+
+148
+00:09:55.500 --> 00:10:04.120
+Now you can skip all of that cost and maybe use Firehose to send the data directly to whatever is your final storage to consume the logs.
+
+149
+00:10:04.620 --> 00:10:08.620
+And this is generally something that can happen if you use, for instance, third-party tools for observability.
+
+150
+00:10:08.880 --> 00:10:12.600
+So now there might be more options to make that integration a little bit cheaper.
+
+151
+00:10:13.360 --> 00:10:15.540
+And I think that's always nice.
+
+152
+00:10:15.820 --> 00:10:18.560
+And also, in another sense, it removes a little bit of complexity
+
+153
+00:10:18.560 --> 00:10:23.520
+because your architecture doesn't need a component that just moves data from A to B.
+
+154
+00:10:23.520 --> 00:10:26.400
+Of course, this is not free.
+
+155
+00:10:26.640 --> 00:10:30.580
+There is a cost to use this new S3 or Firehose destination.
+
+156
+00:10:30.880 --> 00:10:35.760
+You still pay up to $0.25 per gigabyte for log delivery to S3 and Firehose.
+
+157
+00:10:36.040 --> 00:10:40.860
+And then, of course, you have the cost of the S3 and Firehose services as well that you need to keep into account.
+
+158
+00:10:41.380 --> 00:10:47.460
+Are there some recommendations that we can give to people in case they maybe want to learn a trick or two
+
+159
+00:10:47.460 --> 00:10:51.660
+on how they can save a little bit of cost when it comes to Lambda and logs in general?
+
+160
+00:10:55.640 --> 00:11:00.580
+Yeah, even if we forget about all of these changes we've discussed today, whether those cost changes impact you at all, the cost of logging is something you should keep an eye on.
+
+161
+00:11:01.000 --> 00:11:03.620
+And we can give you a few relatively quick recommendations.
+
+162
+00:11:03.920 --> 00:11:06.300
+Of course, we'd love to hear your tips, so let us know what you think.
+
+163
+00:11:06.540 --> 00:11:08.860
+Number one is using frequent access wherever possible.
+
+164
+00:11:09.180 --> 00:11:14.720
+We've adopted this since it was made available as our default almost, and we rarely miss standard access mode.
+
+165
+00:11:14.720 --> 00:11:19.280
+It has some limitations, like you can't use LiveTail embedded metrics and metric filters,
+
+166
+00:11:19.800 --> 00:11:23.980
+but you can still use Logs Insights, which is what we primarily use for viewing and searching logs.
+
+167
+00:11:24.420 --> 00:11:27.100
+We have a whole episode on that, actually, which is episode 35.
+
+168
+00:11:27.460 --> 00:11:28.900
+And yeah, you can check that out.
+
+169
+00:11:29.120 --> 00:11:31.880
+I'd also say set the log retention period to a reasonable value.
+
+170
+00:11:32.280 --> 00:11:35.520
+Often you don't need to retain Lambda logs for months, and often by default,
+
+171
+00:11:35.760 --> 00:11:39.340
+they can be retained indefinitely, which can really cause you a lot of pain.
+
+172
+00:11:39.560 --> 00:11:43.240
+Experiment with the other new feature, which is advanced logging controls.
+
+173
+00:11:43.240 --> 00:11:44.880
+I think this was released last year.
+
+174
+00:11:45.540 --> 00:11:50.320
+Lambda can actually filter out verbose logging, like debug level for you, and you can save costs that way.
+
+175
+00:11:50.480 --> 00:11:54.480
+And if you're using AWS Power Tools for Lambda, you can also do debug log sampling,
+
+176
+00:11:54.640 --> 00:12:01.060
+so that it'll only print out debug logs for a certain threshold, certain percentage of events.
+
+177
+00:12:01.200 --> 00:12:02.540
+That can save you a lot, too.
+
+178
+00:12:02.960 --> 00:12:04.820
+And you can also customize that per environment.
+
+179
+00:12:05.180 --> 00:12:09.440
+And again, once features have stabilized, just remove unnecessary informative logging.
+
+180
+00:12:09.440 --> 00:12:15.140
+I've heard stories from people who were investigating cloud costs because it became critical,
+
+181
+00:12:15.560 --> 00:12:19.060
+and they discovered that they were paying thousands every month for logs that say,
+
+182
+00:12:19.400 --> 00:12:20.740
+I'm here on line 23.
+
+183
+00:12:21.380 --> 00:12:23.940
+And that was put in for debug logging during feature development.
+
+184
+00:12:24.200 --> 00:12:29.400
+Somebody forgot to take it out, and it ended up costing tens of thousands of dollars for absolutely no reason.
+
+185
+00:12:29.600 --> 00:12:33.520
+So just to wrap up then, we just gave a quick overview of some of the nice updates
+
+186
+00:12:33.520 --> 00:12:36.260
+that might help us save a few dollars on that AWS bill.
+
+187
+00:12:36.260 --> 00:12:41.720
+We also said we'd mention a shout-out to ForTheorem for powering yet another episode of AWS Bites.
+
+188
+00:12:42.060 --> 00:12:46.220
+And at ForTheorem, we believe that cloud should be simple, scalable, and cost-effective.
+
+189
+00:12:46.500 --> 00:12:48.560
+And we help teams to do just that.
+
+190
+00:12:48.940 --> 00:12:52.320
+Whether you're working with containers, stepping into event-driven architecture,
+
+191
+00:12:52.680 --> 00:12:54.980
+or scaling a global SaaS platform on AWS,
+
+192
+00:12:55.260 --> 00:12:58.800
+or even just trying to keep cloud spend under control, we have your back.
+
+193
+00:12:58.960 --> 00:13:03.020
+So visit fourtheorem.com to see how we can help you build faster, better,
+
+194
+00:13:03.020 --> 00:13:06.020
+and with more confidence using AWS Cloud.
+
+195
+00:13:06.600 --> 00:13:07.080
+And that's all.
+
+196
+00:13:07.300 --> 00:13:08.040
+Let us know what you think.
+
+197
+00:13:08.280 --> 00:13:11.300
+And if you know somebody who might find this episode useful, please share it with them.
+
+198
+00:13:11.780 --> 00:13:12.340
+Thanks again.
+
+199
+00:13:12.680 --> 00:13:13.780
+Until next time, goodbye.

--- a/src/episodes/144-lambda-billing-changes.md
+++ b/src/episodes/144-lambda-billing-changes.md
@@ -1,0 +1,38 @@
+---
+episode: 144
+title: "Lambda Billing Changes, Cold Start Costs, and Log Savings: What You Need to Know"
+youtube_id: "BkxCltzTUZo"
+spotify_link: "https://creators.spotify.com/pod/show/aws-bites/episodes/144--Lambda-Billing-Changes--Cold-Start-Costs--and-Log-Savings-What-You-Need-to-Know-e336tea"
+publish_date: 2025-05-22
+---
+
+Cost is always top of mind when building in the cloud, and recently AWS has
+introduced some changes worth paying attention to. In this episode of AWS Bites,
+we explore a shift that caught many by surprise: the “free” INIT phase for
+Lambda’s managed runtimes is going away. That cold start time that used to fly
+under the billing radar? It's now part of the cost. We dig into what this means
+for your workloads, who might feel the impact, and whether this gives languages
+like Rust and Go an extra edge. But it’s not all bad news. AWS has also rolled
+out new pricing tiers for CloudWatch Logs, making it cheaper for high-volume
+accounts. On top of that, there are new options to send logs directly to S3 or
+Firehose, helping simplify pipelines and reduce costs. We close with a few tips
+to help you keep your Lambda and logging spend under control. If you're building
+on AWS and care about efficiency, this is one you won't want to miss.
+
+> Big shoutout to fourTheorem for powering yet another episode of AWS Bites. At
+> fourTheorem, we believe the cloud should be simple, scalable, and
+> cost-effective, and we help teams do just that. Whether you’re diving into
+> containers, stepping into event-driven architecture, or scaling a global SaaS
+> platform on AWS, or trying to keep cloud spend under control our team has your
+> back. Visit [fourTheorem.com](https://fourTheorem.com) to see how we can help
+> you build faster, better, and with more confidence using AWS cloud!
+
+In this episode, we mentioned the following resources:
+
+- [AWS Blog – Tiered Pricing for AWS Lambda](https://aws.amazon.com/blogs/compute/introducing-tiered-pricing-for-aws-lambda/)
+- [Luc van Donkersgoed – When is the Lambda INIT phase free and when is it billed?](https://lucvandonkersgoed.com/2022/04/09/when-is-the-lambda-init-phase-free-and-when-is-it-billed/)
+- [AWS Bites – Explaining Lambda Runtimes (Episode 104)](https://awsbites.com/104-explaining-lambda-runtimes/)
+- [AWS Blog – Standardized Billing for Lambda INIT Phase](https://aws.amazon.com/blogs/compute/aws-lambda-standardizes-billing-for-init-phase/)
+- [Lambda Cold Start Benchmarks by Maxim David](https://maxday.github.io/lambda-perf/)
+- [Duckbill Group Blog – Lambda Logs Just Got Cheaper](https://www.duckbillgroup.com/blog/lambda-logs-just-got-cheaper/)
+- [AWS Bites – Becoming a Logs Ninja with CloudWatch (Episode 35)](https://awsbites.com/35-how-can-you-become-a-logs-ninja-with-cloudwatch)


### PR DESCRIPTION

# Transcript

This change includes the transcript for the podcast episode, created by [Podwhisperer](https://github.com/fourTheorem/podwhisperer).
The summary below is generated by [Episoder](https://github.com/fourTheorem/episoder).

## Episode Summary

In this episode, we discuss recent updates to AWS Lambda billing, including the removal of free init time for managed runtimes. We talk about the potential impact this could have on costs, and whether it makes a case for compiled runtimes like Rust and Go. We then cover the new tiered CloudWatch Logs pricing based on usage volumes, which can significantly reduce costs for high-volume accounts. We also discuss the new ability to send Lambda logs directly to S3 and Kinesis Firehose instead of CloudWatch Logs. Finally, we provide several tips for reducing overall Lambda and logging costs on AWS.

## Suggested Chapters
00:00 Introduction to recent AWS billing updates impacting Lambda and CloudWatch Logs costs.
00:38 Overview of Lambda billing model and new changes to init time billing.
03:15 Discussion of the removal of free init time and potential impact on costs.
07:43 New tiered CloudWatch Logs pricing based on high usage volumes can reduce costs.
09:28 Ability to send Lambda logs directly to S3 and Firehose instead of CloudWatch Logs.
10:55 Tips for reducing overall Lambda and logging costs on AWS.

## Suggested Tags
AWS, Cloud, Serverless, Lambda, CloudWatch Logs, Billing, Cost Optimization, Cost Savings, Init Time, Cold Starts, Logs, S3, Firehose, Kinesis, NodeJS, Python, Java, Go, Rust, C++, Custom Runtimes, Compiled Languages, Observability, Monitoring
