### PR TITLE
add episode 146 transcript

### DIFF
--- a/src/_transcripts/146.json
+++ b/src/_transcripts/146.json
@@ -1,7 +1,7 @@
 {
   "speakers": {
-    "spk_0": "spk_0",
-    "spk_1": "spk_1"
+    "spk_0": "Eoin",
+    "spk_1": "Luciano"
   },
   "segments": [
     {
@@ -44,7 +44,7 @@
       "speakerLabel": "spk_0",
       "start": 43.4,
       "end": 47.92,
-      "text": " This episode is brought to you by 4Theorem, stay tuned for more about that at the end of the show."
+      "text": " This episode is brought to you by fourTheorem, stay tuned for more about that at the end of the show."
     },
     {
       "speakerLabel": "spk_0",
@@ -101,7 +101,7 @@
       "text": " So why do you think they might be doing it, Luciano?"
     },
     {
-      "speakerLabel": "spk_0",
+      "speakerLabel": "spk_1",
       "start": 96.54,
       "end": 105.7,
       "text": " Yeah, it's interesting because I think one of the things that I always loved about AWS is that they used to be famous for keeping services running pretty much forever, no matter what."
@@ -143,7 +143,7 @@
       "text": " So, yeah, why do you think that AWS has been cleaning up more and more lately?"
     },
     {
-      "speakerLabel": "spk_1",
+      "speakerLabel": "spk_0",
       "start": 149.08,
       "end": 152.96,
       "text": " Well, we can only guess, but some of the reasons might be it had to happen sometime."
@@ -644,7 +644,7 @@
       "speakerLabel": "spk_0",
       "start": 516.22,
       "end": 518.46,
-      "text": " Go to awsbytes.com slash 143."
+      "text": " Go to awsbites.com/143"
     },
     {
       "speakerLabel": "spk_0",
@@ -752,7 +752,7 @@
       "speakerLabel": "spk_1",
       "start": 594.96,
       "end": 600.9,
-      "text": " So go to awsbytes.com slash 74 if you want to get more details on all the options that you have available."
+      "text": " So go to awsbites.com/74 if you want to get more details on all the options that you have available."
     },
     {
       "speakerLabel": "spk_1",
@@ -881,7 +881,7 @@
       "text": " Now, Eoin, do you have any other guess?"
     },
     {
-      "speakerLabel": "spk_1",
+      "speakerLabel": "spk_0",
       "start": 689.3000000000001,
       "end": 691.2,
       "text": " Maybe they'll just add v3 and we'll have..."
@@ -899,7 +899,7 @@
       "text": " The one that solves all the problems."
     },
     {
-      "speakerLabel": "spk_1",
+      "speakerLabel": "spk_0",
       "start": 695.04,
       "end": 702.12,
       "text": " All right, so other honorable mentions that we think might hit the chopping block."
@@ -908,19 +908,19 @@
       "speakerLabel": "spk_0",
       "start": 702.24,
       "end": 703.56,
-      "text": " We've got simple workflow service."
+      "text": " We've got Simple Workflow Service."
     },
     {
       "speakerLabel": "spk_0",
       "start": 704.02,
       "end": 707.7199999999999,
-      "text": " I think there are still people using this, but it largely has been superseded by step functions."
+      "text": " I think there are still people using this, but it largely has been superseded by Step Functions."
     },
     {
       "speakerLabel": "spk_0",
       "start": 708.8199999999999,
       "end": 712.74,
-      "text": " The QIIME SDK is something that I don't know if it got a lot of adoption."
+      "text": " The Chime SDK is something that I don't know if it got a lot of adoption."
     },
     {
       "speakerLabel": "spk_0",
@@ -938,7 +938,7 @@
       "speakerLabel": "spk_0",
       "start": 720.14,
       "end": 723.9399999999999,
-      "text": " And QIIME itself is already end of life, so you have to wonder about QIIME SDK."
+      "text": " And Chime itself is already end of life, so you have to wonder about Chime SDK."
     },
     {
       "speakerLabel": "spk_0",
@@ -1118,13 +1118,13 @@
       "speakerLabel": "spk_0",
       "start": 912.34,
       "end": 916.0400000000001,
-      "text": " Finally, big shout out to 4Theorem for powering yet another episode of AWS Bites."
+      "text": " Finally, big shout out to fourTheorem for powering yet another episode of AWS Bites."
     },
     {
       "speakerLabel": "spk_0",
       "start": 916.6600000000001,
       "end": 922.22,
-      "text": " At 4Theorem, we believe the cloud should be simple, scalable, and cost-effective, and we help teams just to do that."
+      "text": " At fourTheorem, we believe the cloud should be simple, scalable, and cost-effective, and we help teams just to do that."
     },
     {
       "speakerLabel": "spk_0",
@@ -1136,7 +1136,7 @@
       "speakerLabel": "spk_0",
       "start": 932.34,
       "end": 938.96,
-      "text": " So visit 4Theorem.com to see how we can help you to build faster, better, and with more confidence using AWS."
+      "text": " So visit fourtheorem.com to see how we can help you to build faster, better, and with more confidence using AWS."
     },
     {
       "speakerLabel": "spk_0",

--- a/src/_transcripts/146.vtt
+++ b/src/_transcripts/146.vtt
@@ -1,0 +1,761 @@
+WEBVTT
+
+1
+00:00:00.000 --> 00:00:04.020
+What if we told you that AWS has its own version of Killed by Google?
+
+2
+00:00:04.560 --> 00:00:10.740
+It's actually an AWS official page that lists which products are being retired, phased out, or closed to new customers.
+
+3
+00:00:11.060 --> 00:00:16.940
+And if you actively use AWS and you use a broad range of services, this is a page you should probably bookmark.
+
+4
+00:00:17.200 --> 00:00:24.340
+Today we're talking about the AWS product lifecycle, what it is, what you'll find there, and how it can help you to avoid nasty surprises.
+
+5
+00:00:24.340 --> 00:00:30.580
+We'll also look at some products that are already on their way out, and maybe even some more predictions on what could be next.
+
+6
+00:00:31.060 --> 00:00:35.660
+Welcome to AWS Bites, I'm Eoin, I'm here again with Luciano, let's jump in.
+
+7
+00:00:43.400 --> 00:00:47.920
+This episode is brought to you by fourTheorem, stay tuned for more about that at the end of the show.
+
+8
+00:00:48.060 --> 00:00:50.500
+So what is the AWS product lifecycle page?
+
+9
+00:00:50.500 --> 00:00:57.660
+Well, AWS quietly launched this page, which is a bit like a changelog for AWS product retirements.
+
+10
+00:00:58.200 --> 00:00:59.100
+The link will be in the show notes.
+
+11
+00:00:59.740 --> 00:01:11.440
+It was only announced in May of this year, and there you'll find products that are being deprecated, services closed to new customers, products entering long-term support, and explicit end-of-life dates.
+
+12
+00:01:12.100 --> 00:01:16.500
+Now, unlike Killed by Google, this isn't a rage-fueled graveyard.
+
+13
+00:01:16.500 --> 00:01:19.660
+It's an attempt to be a transparent and structured overview.
+
+14
+00:01:20.020 --> 00:01:23.420
+It comes from AWS, and we're honestly happy that they made this official.
+
+15
+00:01:24.160 --> 00:01:33.280
+So it gives us developers, teams, enterprises a clear roadmap to avoid surprises, sunsets, and to be able to plan migrations with some time to spare.
+
+16
+00:01:33.820 --> 00:01:36.540
+So why do you think they might be doing it, Luciano?
+
+17
+00:01:36.540 --> 00:01:45.700
+Yeah, it's interesting because I think one of the things that I always loved about AWS is that they used to be famous for keeping services running pretty much forever, no matter what.
+
+18
+00:01:46.200 --> 00:01:50.120
+And one example is SimpleDB that is still available, if I'm not mistaken.
+
+19
+00:01:50.900 --> 00:01:54.900
+Although I think at this point everyone is using replacements like DynamoDB, right?
+
+20
+00:01:54.900 --> 00:02:05.400
+And, yeah, I think this used to be a thing that everyone would be saying in the last few years about AWS, like they're never going to deprecate any service, so it's super stable and everything.
+
+21
+00:02:06.000 --> 00:02:11.620
+But, of course, we know that this is not going to be sustainable forever, and AWS at some point realized that as well.
+
+22
+00:02:11.620 --> 00:02:20.700
+And there was a moment where AWS started to deprecate a few services, and there was a little bit of backlash.
+
+23
+00:02:21.440 --> 00:02:28.480
+So, yeah, why do you think that AWS has been cleaning up more and more lately?
+
+24
+00:02:29.080 --> 00:02:32.960
+Well, we can only guess, but some of the reasons might be it had to happen sometime.
+
+25
+00:02:33.340 --> 00:02:38.580
+You can't just keep adding services and support them without having enormous maintenance costs on the AWS side.
+
+26
+00:02:38.580 --> 00:02:47.640
+They also laid off quite a few staff last year, and you can imagine that this means you have to focus on certain product priorities and cutting back on others.
+
+27
+00:02:48.500 --> 00:02:53.960
+I also wonder if AI and Gen AI in particular has caused a big focus shift.
+
+28
+00:02:54.240 --> 00:03:00.200
+We know that so many announcements and so much marketing from AWS over the past year or so has been around AI, Q, RedRock.
+
+29
+00:03:00.660 --> 00:03:05.320
+So this sudden shift must mean that some things have to hit the scrap heap to make room.
+
+30
+00:03:05.320 --> 00:03:08.000
+Should we talk a bit about what's on this product lifecycle page?
+
+31
+00:03:08.000 --> 00:03:12.460
+A lot of people might be surprised to hear what's on there and what's already on the chopping block.
+
+32
+00:03:12.860 --> 00:03:13.080
+Yes.
+
+33
+00:03:13.260 --> 00:03:14.660
+So this is at the time of the recording.
+
+34
+00:03:14.820 --> 00:03:18.560
+Of course, we expect this page to evolve over time, so always keep an eye.
+
+35
+00:03:19.360 --> 00:03:25.980
+And if we are listening right now as we just published this episode, hopefully this is still going to be pretty relevant.
+
+36
+00:03:26.580 --> 00:03:29.540
+So the important thing, I think, is that there are different categories.
+
+37
+00:03:29.760 --> 00:03:33.180
+So the first one is services closing access to new customers.
+
+38
+00:03:33.180 --> 00:03:39.740
+So the idea is that if you are using a service already today, that service is not going to go away for you immediately.
+
+39
+00:03:39.740 --> 00:03:44.780
+But it's more if somebody is getting a new account, that service is not going to be available in that new account.
+
+40
+00:03:44.780 --> 00:03:57.580
+So that is, of course, a strategy that AWS puts in place to give existing customers time to migrate out while they don't want, of course, to overload themselves with new customers as they are trying to phase out a product.
+
+41
+00:03:58.140 --> 00:04:02.980
+And just to give you one example of what's there right now, there is Amazon Timestream for live analytics.
+
+42
+00:04:02.980 --> 00:04:10.500
+And if you look at the official docs, it's interesting that they are already recommending to use Amazon Timestream for influx DB as an alternative.
+
+43
+00:04:10.980 --> 00:04:13.400
+So there is already some kind of a migration plan.
+
+44
+00:04:13.940 --> 00:04:19.700
+I'm not sure if there are additional tutorials or guides from AWS, but I wouldn't be surprised if you search for them.
+
+45
+00:04:19.740 --> 00:04:21.900
+Maybe you'll find something like that.
+
+46
+00:04:22.200 --> 00:04:26.100
+But this is just to give you an example of what might be appearing in this section.
+
+47
+00:04:26.100 --> 00:04:30.320
+And, yeah, if you're using Timestream, I think Timestream is still available.
+
+48
+00:04:30.500 --> 00:04:34.980
+It's more this particular variation of Timestream is going to go away.
+
+49
+00:04:35.060 --> 00:04:37.580
+So just be aware if you are a user of Timestream.
+
+50
+00:04:38.100 --> 00:04:42.260
+I'm personally not an expert in Timestream, so hopefully I'm not saying anything misleading.
+
+51
+00:04:43.080 --> 00:04:46.820
+Now, another category is services announcing end of support.
+
+52
+00:04:47.100 --> 00:04:51.340
+And this is the one that I think right now has the biggest list of products.
+
+53
+00:04:51.340 --> 00:04:56.000
+And there are services that are officially heading for retirement.
+
+54
+00:04:56.240 --> 00:04:59.200
+So AWS is starting to provide migration paths and timelines.
+
+55
+00:04:59.700 --> 00:05:05.320
+And this is where you really want to pay attention because, of course, the sooner you're going to catch something there,
+
+56
+00:05:05.380 --> 00:05:10.360
+the more prepared you can be to figure out what is a strategy to move out from those services if you're using them.
+
+57
+00:05:10.600 --> 00:05:16.120
+Now, to give you an example, the first one worth mentioning is Amazon Pinpoint, just because I can say we told you.
+
+58
+00:05:16.840 --> 00:05:17.760
+Of course, I'm joking.
+
+59
+00:05:17.760 --> 00:05:22.440
+We made an episode, episode 98, I think it was almost two years ago at this point,
+
+60
+00:05:22.840 --> 00:05:28.340
+where we were discussing some of the drastic quota changes that Amazon put in place for Pinpoint.
+
+61
+00:05:28.860 --> 00:05:34.520
+And we got a little bit suspicious that maybe as a service it wasn't getting a lot of traction
+
+62
+00:05:34.520 --> 00:05:37.080
+or maybe it was too difficult to maintain at that scale.
+
+63
+00:05:37.320 --> 00:05:40.520
+So we just assumed that it eventually might have been phased out.
+
+64
+00:05:40.680 --> 00:05:41.720
+And so it happens.
+
+65
+00:05:41.860 --> 00:05:43.180
+Maybe we were right, just like it.
+
+66
+00:05:43.700 --> 00:05:47.280
+But yes, this is an example of the kind of products you can see here.
+
+67
+00:05:47.280 --> 00:05:55.500
+Other examples are AWS IQ, which is the marketplace for freelancers, where effectively, if you have AWS skills, you can look for customers.
+
+68
+00:05:56.440 --> 00:06:02.280
+And we expect that, yeah, since this is going for retirement, AWS doesn't want to maintain that marketplace themselves.
+
+69
+00:06:02.520 --> 00:06:07.700
+Maybe there will be other alternatives that are not strictly officially promoted by AWS.
+
+70
+00:06:07.700 --> 00:06:13.060
+And then we have two IoT services, AWS IoT Analytics and IoT Events.
+
+71
+00:06:13.520 --> 00:06:18.280
+And we also have AWS Panorama, which is if you're doing computer visions and you want to do it on premise.
+
+72
+00:06:18.500 --> 00:06:20.800
+That's the kind of service that AWS used to provide.
+
+73
+00:06:21.040 --> 00:06:25.700
+Now, again, these services are not gone yet, but we can expect that they will eventually go.
+
+74
+00:06:26.600 --> 00:06:29.020
+So start to prepare yourself if you're using them.
+
+75
+00:06:29.280 --> 00:06:30.320
+Start to look at the documentation.
+
+76
+00:06:30.320 --> 00:06:36.000
+Start to see what AWS suggests as a migration path and just be aware about the timelines.
+
+77
+00:06:36.340 --> 00:06:40.120
+Now, the next one is services and features reaching end of support.
+
+78
+00:06:40.340 --> 00:06:42.700
+So these ones are services that are already gone.
+
+79
+00:06:42.880 --> 00:06:44.340
+So the end of life has been reached.
+
+80
+00:06:44.940 --> 00:06:48.060
+And if you try to use them now, you will basically hit a wall.
+
+81
+00:06:48.400 --> 00:06:51.820
+And two elements, two services are there right now.
+
+82
+00:06:51.820 --> 00:06:55.160
+And there is AWS Private 5G and AWS Data Sync Discovery.
+
+83
+00:06:55.820 --> 00:07:02.920
+Now, there is also a generic note that says if you are affected or unsure, reach out to AWS support or check the specific service documentation.
+
+84
+00:07:03.620 --> 00:07:08.260
+So just be aware that, yeah, this seems like a little bit of a vague suggestion.
+
+85
+00:07:08.260 --> 00:07:13.160
+But I honestly suspect that this is just because this section is probably something that AWS is still working on.
+
+86
+00:07:13.300 --> 00:07:15.020
+And they will probably improve it as they go.
+
+87
+00:07:15.300 --> 00:07:19.660
+There are actually services that are already end of life, but predate this product lifecycle page.
+
+88
+00:07:19.800 --> 00:07:20.500
+And they're not there yet.
+
+89
+00:07:20.500 --> 00:07:24.940
+One example is OpsWorks, which was, I think, reasonably popular.
+
+90
+00:07:25.060 --> 00:07:26.860
+It managed Chef and Puppet solution.
+
+91
+00:07:27.480 --> 00:07:29.680
+And that has been end of life since May 24.
+
+92
+00:07:30.300 --> 00:07:36.800
+And other examples include Chime, CodeCommit, Cloud9, and QLDB or Quantum LedgerDB.
+
+93
+00:07:37.100 --> 00:07:42.800
+A lot of those were not quite announced, but they were deprecated or sunsetted around the same time.
+
+94
+00:07:43.380 --> 00:07:49.080
+And there was quite a bit of backlash from the community on the lack of communication when these deprecations happened,
+
+95
+00:07:49.080 --> 00:07:53.320
+especially with CodeCommit, because that's something people really rely on if they're using it.
+
+96
+00:07:53.320 --> 00:07:58.000
+And also you had things like control tower solutions being based heavily on CodeCommit.
+
+97
+00:07:58.120 --> 00:07:59.880
+So it was not handled very well.
+
+98
+00:08:00.260 --> 00:08:07.240
+Maybe this product lifecycle page is AWS's way of trying to address those communication issues and do things a bit better for the future.
+
+99
+00:08:07.240 --> 00:08:14.500
+Now, with all that said, let's get into crystal ball time and try and think of what other services might be deprecated in the future.
+
+100
+00:08:14.820 --> 00:08:17.140
+Now, big disclaimer, we don't have any insider knowledge.
+
+101
+00:08:17.600 --> 00:08:20.700
+And if we did, we wouldn't use that here or disclose it here.
+
+102
+00:08:20.940 --> 00:08:24.380
+So this is just a guessing game and a random chat at the bar between friends.
+
+103
+00:08:24.380 --> 00:08:25.980
+So here are a few guesses.
+
+104
+00:08:26.480 --> 00:08:28.740
+There's so many different ways to run a container on AWS.
+
+105
+00:08:29.320 --> 00:08:31.420
+You can imagine that at some point they might like to consolidate.
+
+106
+00:08:32.320 --> 00:08:35.380
+And we talked recently about AppRunner in episode 143.
+
+107
+00:08:36.220 --> 00:08:38.460
+Go to awsbites.com/143
+
+108
+00:08:39.200 --> 00:08:41.600
+And I have to say we've really liked it in principle.
+
+109
+00:08:41.760 --> 00:08:47.960
+The only problem is that there's still a lot of overlap with other services, a bit of Fargate, a bit of Beanstalk, Elastic Beanstalk.
+
+110
+00:08:47.960 --> 00:08:54.720
+It always felt like AppRunner was going to, well, it was at least a candidate to replace Elastic Beanstalk for some use cases.
+
+111
+00:08:55.180 --> 00:08:57.620
+But in reality, we haven't seen that much development on it.
+
+112
+00:08:58.120 --> 00:09:01.480
+So is one of those two going to be sunsetted eventually?
+
+113
+00:09:01.760 --> 00:09:02.600
+If yes, which one?
+
+114
+00:09:03.040 --> 00:09:08.440
+Is there going to be some sort of consolidation of container services under an umbrella?
+
+115
+00:09:08.580 --> 00:09:10.200
+Maybe the Fargate umbrella would be nice.
+
+116
+00:09:10.580 --> 00:09:15.960
+Just to make it easier for people to pick and choose those services and to switch between them.
+
+117
+00:09:15.960 --> 00:09:21.660
+And I guess when it comes to the actual deprecation of them, customer adoption is probably going to dictate that.
+
+118
+00:09:21.980 --> 00:09:26.840
+Yeah, if you want my guess, one of the areas where I've always struggled the most is API Gateway.
+
+119
+00:09:27.160 --> 00:09:30.680
+And especially version one versus version two.
+
+120
+00:09:31.360 --> 00:09:36.380
+And I think that's very common for full stack developers, web developers using AWS.
+
+121
+00:09:36.920 --> 00:09:38.460
+They build lots of APIs.
+
+122
+00:09:38.660 --> 00:09:42.020
+And it's always a little bit of a struggle to figure out which one do I use.
+
+123
+00:09:42.020 --> 00:09:52.060
+And we spoke about API Gateway, the different versions and other ways to create HTTP endpoints basically on AWS in a serverless fashion.
+
+124
+00:09:52.280 --> 00:09:54.680
+And back in episode 74.
+
+125
+00:09:54.960 --> 00:10:00.900
+So go to awsbites.com/74 if you want to get more details on all the options that you have available.
+
+126
+00:10:00.900 --> 00:10:06.600
+But my point is that basically these two versions of API Gateway are effectively competing for features.
+
+127
+00:10:07.400 --> 00:10:14.380
+And for sure, inside AWS, there is a little bit of a waste of development energies, maintenance, management, and everything else.
+
+128
+00:10:14.380 --> 00:10:18.280
+Because effectively, they have to mandate two things that are trying to do the same thing.
+
+129
+00:10:18.440 --> 00:10:19.720
+Maybe in slightly different ways.
+
+130
+00:10:19.820 --> 00:10:22.200
+Maybe more optimized on different areas.
+
+131
+00:10:22.400 --> 00:10:26.900
+But effectively, from the customer perspective, it's very difficult to pick one over another.
+
+132
+00:10:26.900 --> 00:10:34.800
+So that's probably an area where AWS will eventually have to make a choice, even to just simplify for the customers, not just for themselves.
+
+133
+00:10:35.140 --> 00:10:38.600
+But the interesting guess is which one is going to go, right?
+
+134
+00:10:38.600 --> 00:10:41.140
+Because you might think that v2 is the newer one.
+
+135
+00:10:41.300 --> 00:10:45.000
+It's also maybe a little bit cheaper, a little bit faster, based on some benchmarks.
+
+136
+00:10:45.260 --> 00:10:50.860
+So it's easy to expect that v2 is the one that's going to stay and v1 is going to be phased out.
+
+137
+00:10:50.860 --> 00:10:56.180
+But in reality, it's fair to say that v1 still has a lot more features and integrations with other AWS services.
+
+138
+00:10:56.640 --> 00:10:58.580
+So the choice, I don't think, is that obvious.
+
+139
+00:10:59.280 --> 00:11:00.700
+So what do you think?
+
+140
+00:11:00.820 --> 00:11:03.980
+Do you think v1 is going to win or v2 is going to win?
+
+141
+00:11:04.200 --> 00:11:05.540
+Let us know in the comments.
+
+142
+00:11:05.680 --> 00:11:10.440
+But if you want to know our guess, I think v2 is the one that is going to lose, not stay.
+
+143
+00:11:10.440 --> 00:11:17.560
+Just because our guess is based on recent announcements, and so it happens that there were more recent announcements for v1.
+
+144
+00:11:18.520 --> 00:11:23.780
+Specifically, the last one was an API gateway v1 announcement called dynamic routing.
+
+145
+00:11:23.980 --> 00:11:26.100
+We'll have the link in the show notes if you're curious.
+
+146
+00:11:26.800 --> 00:11:28.660
+Now, Eoin, do you have any other guess?
+
+147
+00:11:29.300 --> 00:11:31.200
+Maybe they'll just add v3 and we'll have...
+
+148
+00:11:31.200 --> 00:11:32.580
+Ooh, that might be, yeah.
+
+149
+00:11:33.260 --> 00:11:35.040
+The one that solves all the problems.
+
+150
+00:11:35.040 --> 00:11:42.120
+All right, so other honorable mentions that we think might hit the chopping block.
+
+151
+00:11:42.240 --> 00:11:43.560
+We've got Simple Workflow Service.
+
+152
+00:11:44.020 --> 00:11:47.720
+I think there are still people using this, but it largely has been superseded by Step Functions.
+
+153
+00:11:48.820 --> 00:11:52.740
+The Chime SDK is something that I don't know if it got a lot of adoption.
+
+154
+00:11:52.880 --> 00:11:55.980
+We've definitely used it on a previous project, and it worked very well.
+
+155
+00:11:56.340 --> 00:11:59.620
+Unfortunately, it never had cloud formation support, which is a bad, bad smell.
+
+156
+00:12:00.140 --> 00:12:03.940
+And Chime itself is already end of life, so you have to wonder about Chime SDK.
+
+157
+00:12:03.940 --> 00:12:10.500
+Now, maybe a controversial one, serverless application repository, or SAR, only because we haven't seen too much adoption.
+
+158
+00:12:10.800 --> 00:12:14.440
+Now, we like the idea, and we use it, and we publish to the serverless application repository.
+
+159
+00:12:14.860 --> 00:12:19.080
+It's also kind of a hard one to deprecate if a significant number of people depend on it.
+
+160
+00:12:19.600 --> 00:12:24.380
+So it's hard to see it being completely deprecated, but it would be great to see more adoption.
+
+161
+00:12:24.720 --> 00:12:29.900
+Another victim might be Neptune, the graph database that AWS has.
+
+162
+00:12:29.900 --> 00:12:42.940
+Now, we haven't heard that many people using it, and the people we have heard of using it give us this kind of non-scientific conclusion that most people prefer to host Neo4j or something else when they need a graph database.
+
+163
+00:12:43.520 --> 00:12:45.720
+So maybe that's another candidate.
+
+164
+00:12:45.720 --> 00:12:57.780
+In the whole Alexa, Lex space, especially given so much upheaval and development around Gen.AI, we can imagine those services being replaced by Bedrock or Q or something under that umbrella.
+
+165
+00:12:57.780 --> 00:13:09.700
+They've already announced a new Alexa replacement, or ex-premium version called Alexa Plus, which seems to be a paid solution, and it's all based on Gen.AI.
+
+166
+00:13:10.060 --> 00:13:12.860
+So I guess all these services are going to have to improve anyway.
+
+167
+00:13:13.120 --> 00:13:19.480
+The kind of pre-LLM voice assistants tend to be much worse as a user experience anyway.
+
+168
+00:13:19.900 --> 00:13:22.740
+So maybe Alexa is going to get the boot.
+
+169
+00:13:22.740 --> 00:13:34.780
+And in the areas of DevOps and containers, Proton, which is something that was announced a couple of years ago, a lot of people were curious about it, but I just haven't seen that much adoption in practice.
+
+170
+00:13:34.780 --> 00:13:46.520
+It was intended to make the whole infrastructure versus development teams, deployment pipelines for organizations that had separate Ops and Dev pillars.
+
+171
+00:13:46.520 --> 00:13:50.280
+It was intended to make that much easier, but I just haven't heard that much.
+
+172
+00:13:50.280 --> 00:13:54.360
+It's been pretty much tumbleweed since, so maybe Proton is getting the axe.
+
+173
+00:13:55.080 --> 00:14:04.020
+And then one we did put a lot of effort into an episode on, I have to say, so it would be a shame to see it go, is the Copilot CLI in AWS.
+
+174
+00:14:04.500 --> 00:14:14.520
+Now, this is not to be confused with GitHub Copilot and Microsoft's Copilot everything, but we also haven't seen too much about the Copilot CLI.
+
+175
+00:14:14.520 --> 00:14:24.160
+And it was convenient to see a lot from deploying containers on AWS, and we did a whole live coding episode that turned out to be way much more work than we anticipated.
+
+176
+00:14:24.740 --> 00:14:30.040
+So we still got some battle scars from that, but it was still a learning experience.
+
+177
+00:14:30.440 --> 00:14:31.380
+So that's our list.
+
+178
+00:14:31.500 --> 00:14:34.420
+Now, those are, remember, just our guesses.
+
+179
+00:14:34.420 --> 00:14:39.700
+There's nothing there that you should necessarily bet on.
+
+180
+00:14:40.600 --> 00:14:41.800
+But let us know what you think.
+
+181
+00:14:42.780 --> 00:14:51.580
+Hopefully, at least now you know where to look when AWS decides to sunset a service, and maybe we helped you to spot a few warning signs before they become headaches.
+
+182
+00:14:52.320 --> 00:14:55.840
+Just because we were right about pinpoint doesn't mean we're right about the rest.
+
+183
+00:14:55.840 --> 00:15:04.020
+We're not trying to play AWS Doom Clock here, but we just want to make sure we're all informed, especially if you're making long-term architecture decisions.
+
+184
+00:15:04.780 --> 00:15:08.220
+And at least this product lifecycle page is a good tool to keep in your back pocket.
+
+185
+00:15:08.660 --> 00:15:12.080
+Let us know what you think and give us a share of your guesses in the comments.
+
+186
+00:15:12.340 --> 00:15:16.040
+Finally, big shout out to fourTheorem for powering yet another episode of AWS Bites.
+
+187
+00:15:16.660 --> 00:15:22.220
+At fourTheorem, we believe the cloud should be simple, scalable, and cost-effective, and we help teams just to do that.
+
+188
+00:15:22.220 --> 00:15:32.140
+Whether you're diving into containers, stepping into event-driven architectures, or scaling up a global SaaS platform on AWS, even if you're trying to keep cloud spend under control, our team has your back.
+
+189
+00:15:32.340 --> 00:15:38.960
+So visit fourtheorem.com to see how we can help you to build faster, better, and with more confidence using AWS.
+
+190
+00:15:39.380 --> 00:15:41.260
+Thanks very much, and we'll catch you in the next episode.


### PR DESCRIPTION

# Transcript

This change includes the transcript for the podcast episode, created by [Podwhisperer](https://github.com/fourTheorem/podwhisperer).
The summary below is generated by [Episoder](https://github.com/fourTheorem/episoder).

## Episode Summary

In this episode, we discuss the new AWS product lifecycle page, which lists AWS services that are being retired or deprecated. We talk about why AWS created this page for more transparency, and review some of the services already on the chopping block like Amazon Pinpoint and AWS IQ. We also speculate on what other services might get deprecated in the future, like API Gateway v1 or v2, Alexa, and more. Overall, this page helps us plan ahead when services reach end-of-life.

## Suggested Chapters
00:00 Introduction to the AWS product lifecycle page
00:50 Overview of what the product lifecycle page contains
01:36 Discussing why AWS started deprecating more services recently
03:12 Looking at the services currently listed on the product lifecycle page
07:15 Mentioning other already deprecated services not listed yet
08:07 Speculating on what other services might get deprecated in the future
14:31 Recap and concluding thoughts

## Suggested Tags
AWS, Cloud, Deprecation, Sunsetting, Product Lifecycle, Pinpoint, IQ, API Gateway, Alexa, Fargate, Elastic Beanstalk, AppRunner, Lex, QIIME, Neptune, Proton, Copilot, Containers, Serverless, Architecture, Planning, Migration
