### PR TITLE
fix: short URLs should redirect to absolute URLs

### DIFF
--- a/src/episodes-redirects.11ty.js
+++ b/src/episodes-redirects.11ty.js
@@ -12,7 +12,7 @@ class EpisodesRedirects {
     const redirects = []
 
     for (const item of collections.publishedEpisodes.reverse()) {
-      redirects.push(`/${item.data.episode} ${settings.website}${item.url}`)
+      redirects.push(`/${item.data.episode} ${new URL(item.url, settings.website).toString()}`)
     }
 
     return redirects.join('\n')


### PR DESCRIPTION
This is probably the root cause why our short URLs sometimes are not properly rendered on socials (e.g. Slack)