### PR TITLE
Replace Orama with Pagefind for static, local search

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -64,6 +64,13 @@ module.exports = function (eleventyConfig) {
       .sort((a, b) => a.data.publish_date - b.data.publish_date)
   })
 
+  eleventyConfig.on('eleventy.after', async () => {
+    const { createIndex } = await import('pagefind')
+    const { index } = await createIndex({ verbose: false })
+    await index.addDirectory({ path: 'dist' })
+    await index.writeFiles({ outputPath: 'dist/pagefind' })
+  })
+
   // minify html pages
   eleventyConfig.addTransform('htmlmin', function (content, outputPath) {
     if (

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,13 +54,6 @@ jobs:
           deploy_alias: ${{ env.DEPLOY_ALIAS }}
           build_directory: dist
 
-      - name: Publish new Orama Index
-        run: |
-          curl https://api.oramasearch.com/api/v1/indexes/queue-deployment \
-          -H 'content-type: application/json' \
-          -d '{"indexId":"juevpr4vk3mdx6g8be3i20t8"}' \
-          -H "Authorization: Bearer ${{ secrets.ORAMA_PRIVATE_API_KEY}}"
-
       # Creates a status check with link to preview
       - name: Get Netlify Status / Preview URL
         if: ${{ env.DEPLOY_TO_PROD != 'true' }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "luxon": "^3.1.1",
         "node-webvtt": "^1.9.4",
         "npm-run-all": "^4.1.5",
+        "pagefind": "^1.4.0",
         "rimraf": "^3.0.2",
         "sharp": "^0.33.2",
         "striptags": "^3.2.0",
@@ -805,6 +806,104 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@sindresorhus/slugify": {
       "version": "1.1.2",
@@ -4788,6 +4887,25 @@
         "node": ">=4"
       }
     },
+    "node_modules/pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
+      }
+    },
     "node_modules/param-case": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
@@ -7108,6 +7226,55 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "dev": true,
+      "optional": true
+    },
+    "@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "dev": true,
+      "optional": true
+    },
+    "@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "dev": true,
+      "optional": true
+    },
+    "@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "dev": true,
+      "optional": true
+    },
+    "@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "dev": true,
+      "optional": true
+    },
+    "@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "dev": true,
+      "optional": true
     },
     "@sindresorhus/slugify": {
       "version": "1.1.2",
@@ -10121,6 +10288,21 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "dev": true
+    },
+    "pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "dev": true,
+      "requires": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
+      }
     },
     "param-case": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "luxon": "^3.1.1",
     "node-webvtt": "^1.9.4",
     "npm-run-all": "^4.1.5",
+    "pagefind": "^1.4.0",
     "rimraf": "^3.0.2",
     "sharp": "^0.33.2",
     "striptags": "^3.2.0",

--- a/src/_data/settings.js
+++ b/src/_data/settings.js
@@ -14,9 +14,7 @@ const settings = {
     { name: 'Overcast', href: 'https://overcast.fm/itunes1585489017/' },
     { name: 'Pocket Casts', href: 'https://pca.st/wgu0m6rr' },
     { name: 'Amazon Podcasts', href: 'https://music.amazon.com/podcasts/5c10087d-658a-48c1-a9da-ddc8503d4edc/aws-bites' }
-  ],
-  orama_endpoint: 'https://cloud.orama.run/v1/indexes/podcast-episodes-ibb4vk',
-  orama_apikey: 'DUfUCmH9yhiPrbVA5dVyDfuVThI61dQY'
+  ]
 }
 
 settings.links_by_name = settings.links.reduce((acc, curr) => {

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -46,6 +46,7 @@
 
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for AWS Bites" href="{{ settings.rss_link }}"/>
 
+    <link rel="stylesheet" href="/pagefind/pagefind-ui.css">
     <link rel="stylesheet" href="/style.css">
 
     {% if settings.analytics_id %}
@@ -60,17 +61,12 @@
       </script>
     {% endif %}
 
-    {% if settings.orama_endpoint and settings.orama_apikey %}
-      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@orama/wc-components@latest/dist/orama-ui/orama-ui.css"/>
-      <script type="module" src="https://cdn.jsdelivr.net/npm/@orama/wc-components@latest/dist/orama-ui/orama-ui.esm.js"></script>
-      <script nomodule src="https://cdn.jsdelivr.net/npm/@orama/wc-components@latest/dist/cjs/orama-ui.cjs.js"></script>
-    {% endif %}
   </head>
 
   <body class="bg-gray-200 dark:bg-gray-800">
     {% block body %}
       {% block body_header %}
-        <div class="max-w-6xl mx-auto px-6 py-4">
+        <div data-pagefind-ignore class="max-w-6xl mx-auto px-6 py-4">
           <div class="flex justify-between items-center">
             {% if is_generic %}
               <h1 class="sr-only">
@@ -87,14 +83,7 @@
               {% include 'images/logo.svg' %}
             </a>
 
-            {% if settings.orama_endpoint and settings.orama_apikey %}
-              <div class="w-full max-w-md px-2">
-                <div id="orama-ui">
-                  <orama-search-button onClick="open = !open">Search...</orama-search-button>
-                  <orama-search-box></orama-search-box>
-                </div>
-              </div>
-            {% endif %}
+            <div id="search" class="w-full max-w-md px-2"></div>
 
             <button id="toggle-theme" aria-label="Toggle Dark Mode" type="button" class="hidden w-10 h-10 p-3 rounded bg-gray-300 dark:bg-primary-700">
               <svg id="toggle-dark-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" class="w-4 h-4 text-primary-500 dark:text-secondary-500">
@@ -115,7 +104,7 @@
         {{ content | safe }}
       {% endblock body_content %}
       {% block body_footer %}
-        <footer class="footer bg-slate-300 dark:bg-slate-900 py-12 relative mt-24">
+        <footer data-pagefind-ignore class="footer bg-slate-300 dark:bg-slate-900 py-12 relative mt-24">
           <div class="container mx-auto px-6">
 
             <div class="sm:flex sm:mt-8">
@@ -206,13 +195,6 @@
 
               localStorage.theme = 'light'
             }
-
-            document
-              .querySelector("orama-search-button")
-              .colorScheme = theme
-            document
-              .querySelector("orama-search-box")
-              .colorScheme = theme
           }
 
           function toggleTheme() {
@@ -235,46 +217,48 @@
             .classList
             .remove('no-js');
 
-          {% if settings.orama_endpoint and settings.orama_apikey %}
-            let open = false;
-            const searchBoxConfig = {
-              disableChat: true,
-              resultMap: {
-                id: "url",
-                path: "url",
-                title: "title",
-                description: "abstract"
-              },
-              sourcesMap: {
-                id: "url",
-                path: "url",
-                title: "title",
-                description: "abstract"
-              },
-              colorScheme: "system",
-              themeConfig: {
-                "light": {
-                  "--text-color-tertiary": "#4d4c52",
-                  "--background-color-secondary": "#e5e7eb"
-                }
-              }
-            };
-
-            Object.assign(document.querySelector("orama-search-box"), {
-              ...searchBoxConfig,
-              open: open,
-              index: {
-                endpoint: "{{ settings.orama_endpoint }}",
-                api_key: "{{ settings.orama_apikey }}"
-              }
-            });
-          {% endif %}
-
           if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
             setTheme('dark')
           } else {
             setTheme('light')
           }
+        </script>
+        <script src="/pagefind/pagefind-ui.js"></script>
+        <script>
+          window.addEventListener('DOMContentLoaded', () => {
+            new PagefindUI({
+              element: '#search',
+              showSubResults: true,
+              showImages: false,
+              resetStyles: false
+            })
+
+            const searchEl = document.getElementById('search')
+            const searchInput = () => searchEl.querySelector('input.pagefind-ui__search-input')
+            const resultLinks = () => [...searchEl.querySelectorAll('.pagefind-ui__result-link')]
+
+            searchEl.addEventListener('keydown', (e) => {
+              const links = resultLinks()
+              const idx = links.indexOf(document.activeElement)
+
+              if (e.key === 'ArrowDown') {
+                if (!links.length) return
+                e.preventDefault()
+                links[Math.min(idx + 1, links.length - 1)].focus()
+              } else if (e.key === 'ArrowUp') {
+                if (idx === -1) return
+                e.preventDefault()
+                if (idx === 0) searchInput()?.focus()
+                else links[idx - 1].focus()
+              } else if (e.key === 'Escape') {
+                const input = searchInput()
+                if (!input) return
+                input.value = ''
+                input.dispatchEvent(new Event('input', { bubbles: true }))
+                input.focus()
+              }
+            })
+          })
         </script>
       {% endblock scripts %}
     {% endblock body %}

--- a/src/_includes/episodes_layout.njk
+++ b/src/_includes/episodes_layout.njk
@@ -31,7 +31,7 @@
         </p>
         <div class="lg:mx-32 md:mx-20">
           <iframe id="youtubePlayer" width="100%" height="100%" class="aspect-[16/9]" rel="0"
-            src="https://www.youtube.com/embed/{{ youtube_id }}?enablejsapi=1" title="YouTube video player" frameborder="0" 
+            src="https://www.youtube.com/embed/{{ youtube_id }}?enablejsapi=1" title="YouTube video player" frameborder="0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
       </div>
@@ -50,10 +50,13 @@
         </ul>
       </div>
     {% endif %}
-    <div id="description-content" class="tab-content my-8 px-4 prose prose-sm md:prose-lg lg:prose-xl dark:prose-dark mx-auto">
+    <div id="description-content" data-pagefind-body class="tab-content my-8 px-4 prose prose-sm md:prose-lg lg:prose-xl dark:prose-dark mx-auto">
+      <meta data-pagefind-meta="title" content="{{ episode }}. {{ title }}">
+      <meta data-pagefind-meta="date" content="{{ publish_date | formatDateISO }}">
+      <meta data-pagefind-meta="image" content="{{ youtube_id | youtubePreviewUrl }}">
       {{ content | safe }}
 
-      <div class="py-12">
+      <div data-pagefind-ignore class="py-12">
         <h3>Let's talk!</h3>
         <p>Do you agree with our opinions? Do you have interesting AWS questions you'd like us to chat about? Leave a comment on <a href="{{ youtube_id | youtubeLink }}">YouTube</a> or connect with us on:
           <ul>
@@ -68,8 +71,8 @@
 </div>
 
 {% if transcripts[episode] %}
-  <div id="transcript-content" class="tab-content my-8 px-4 prose prose-sm md:prose-lg lg:prose-xl dark:prose-dark mx-auto font-serif">
-    <div class="font-sans text-sm text-center p-4 bg-slate-300 dark:bg-slate-900">Help us to make this transcription better! If you find an error, please <a href="https://github.com/awsbites/aws-bites-site/edit/main/src/_transcripts/{{ episode }}.json">submit a PR</a> with your corrections.</div>
+  <div id="transcript-content" data-pagefind-body class="tab-content my-8 px-4 prose prose-sm md:prose-lg lg:prose-xl dark:prose-dark mx-auto font-serif">
+    <div data-pagefind-ignore class="font-sans text-sm text-center p-4 bg-slate-300 dark:bg-slate-900">Help us to make this transcription better! If you find an error, please <a href="https://github.com/awsbites/aws-bites-site/edit/main/src/_transcripts/{{ episode }}.json">submit a PR</a> with your corrections.</div>
 
     {% set currentSpeakerLabel = '' %}
 

--- a/src/_includes/styles/tailwind.css
+++ b/src/_includes/styles/tailwind.css
@@ -30,3 +30,65 @@ html body {
 .transcript-segment:hover {
   text-decoration: underline dashed orange 2px;
 }
+
+:root {
+  --pagefind-ui-primary: #5D0DEC;
+  --pagefind-ui-text: #111827;
+  --pagefind-ui-background: #ffffff;
+  --pagefind-ui-border: #e5e7eb;
+  --pagefind-ui-tag: #f3f4f6;
+}
+
+.dark {
+  --pagefind-ui-primary: #F7E5AE;
+  --pagefind-ui-text: #f3f4f6;
+  --pagefind-ui-background: #1f2937;
+  --pagefind-ui-border: #4b5563;
+  --pagefind-ui-tag: #374151;
+}
+
+#search {
+  position: relative;
+}
+
+#search .pagefind-ui__drawer {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  right: 0;
+  z-index: 50;
+  max-height: 75vh;
+  overflow-y: auto;
+  padding: 0.5rem 1.25rem 1rem;
+  background: var(--pagefind-ui-background);
+  border: 1px solid var(--pagefind-ui-border);
+  border-radius: 0.5rem;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+}
+
+#search .pagefind-ui__results-area {
+  margin-top: 0;
+}
+
+#search .pagefind-ui__message {
+  padding: 0.5rem 0;
+}
+
+#search .pagefind-ui__result {
+  padding: 1rem 0;
+}
+
+#search .pagefind-ui__result-link:focus-visible {
+  outline: 2px solid var(--pagefind-ui-primary);
+  outline-offset: 4px;
+  border-radius: 2px;
+}
+
+.dark #search .pagefind-ui__drawer {
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
+}
+
+#search .pagefind-ui__search-input::placeholder {
+  color: var(--pagefind-ui-text);
+  opacity: 0.65;
+}


### PR DESCRIPTION
## Summary

- Orama Cloud (SaaS) stopped working. Replaced with [Pagefind](https://pagefind.app/), which builds a static search index from rendered HTML at build time — no API keys, no external CDN, no reindex webhook.
- Index covers exactly what we want per episode: **title (with number)**, **description**, and **full transcript**. Boilerplate, footer, and nav are excluded.
- Inline search input in the header opens a popup-positioned results drawer themed for light/dark mode. Keyboard navigation works: Arrow Up/Down to walk results, Escape to clear, Enter to open.
- Pagefind runs from an Eleventy `after` hook so `npm start` and `npm run build` both produce a fresh index — no separate command to remember.

## Demo

[awsbites-search-demo.webm](https://github.com/user-attachments/assets/ba673e7b-905b-40eb-aef4-76e754a3b8d7)


## Test plan

- [x] `npm install && npm run clean && npm run build` succeeds and creates `dist/pagefind/`
- [x] Serve `dist/` locally and confirm the search input renders in the header
- [x] Search a transcript-only phrase (e.g. _doctors seeing patients_) returns the matching episode
- [x] Search a title phrase (e.g. _LLM Inference_) returns the right episode at top
- [x] Search excluded boilerplate (e.g. _Do you have interesting AWS questions_) returns 0 results
- [x] Toggle dark mode — popup, input, and results recolor correctly
- [x] Arrow Up/Down navigates results, Escape clears the input, Enter opens the focused result
- [ ] Netlify preview deploy works without the Orama webhook step (the `ORAMA_PRIVATE_API_KEY` secret can be removed from repo settings after merge)